### PR TITLE
Add PrepChef monorepo scaffold

### DIFF
--- a/prepchef/.github/workflows/ci.yml
+++ b/prepchef/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm -ws run build

--- a/prepchef/.gitignore
+++ b/prepchef/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+.DS_Store
+coverage
+*.log
+.tmp
+.dist
+build

--- a/prepchef/README.md
+++ b/prepchef/README.md
@@ -1,0 +1,23 @@
+# PrepChef Monorepo (v1.0)
+
+Downtime-only, compliant commercial-kitchen marketplace.
+
+## Quickstart
+```bash
+# Install deps
+npm i -g npm@^10
+npm install
+
+# Start a couple of services in dev mode
+npm run dev -w services/auth-svc
+npm run dev -w services/booking-svc
+npm run dev -w services/access-svc
+
+# Generate OpenAPI client/server stubs (placeholder)
+npm run codegen
+```
+
+## Services
+- auth-svc, identity-svc, compliance-svc, listing-svc, availability-svc, pricing-svc, payments-svc, booking-svc, access-svc, notif-svc, reviews-svc, admin-svc, audit-svc
+
+See `contracts/openapi.yaml` and `db/schema.sql`.

--- a/prepchef/contracts/openapi.yaml
+++ b/prepchef/contracts/openapi.yaml
@@ -1,0 +1,28 @@
+openapi: 3.1.0
+info:
+  title: PrepChef Public API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3001/v1
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+paths:
+  /auth/login:
+    post:
+      summary: Email/password login
+      responses:
+        '200': { description: JWT issued }
+  /listings:
+    get:
+      summary: Search listings
+      responses:
+        '200': { description: OK }
+  /bookings:
+    post:
+      summary: Create booking
+      responses:
+        '201': { description: Booking created }

--- a/prepchef/db/schema.sql
+++ b/prepchef/db/schema.sql
@@ -1,0 +1,5 @@
+-- Core tables (abridged from spec)
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- users, businesses, venues, kitchen_listings, availability_windows, compliance_documents, bookings, access_grants, reviews, audit_logs
+-- See full spec for detailed DDL

--- a/prepchef/infra/aws/main.tf
+++ b/prepchef/infra/aws/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } }
+  required_version = ">= 1.5.0"
+}
+provider "aws" { region = var.region }
+
+variable "region" { type = string, default = "us-west-2" }
+
+# TODO: RDS, ECS/Lambda, S3, CloudFront, WAF, Secrets Manager

--- a/prepchef/install.sh
+++ b/prepchef/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+npm ci || npm install
+npm -ws run build || true
+echo "Scaffold ready. Start a service: npm run dev -w services/auth-svc"

--- a/prepchef/package.json
+++ b/prepchef/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "prepchef",
+  "private": true,
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*",
+    "services/*"
+  ],
+  "scripts": {
+    "build": "npm -ws run build",
+    "dev": "echo 'Run with -w services/<svc>'",
+    "lint": "npm -ws run lint",
+    "test": "npm -ws run test --if-present",
+    "codegen": "node scripts/codegen-stub.js"
+  }
+}

--- a/prepchef/packages/common/package.json
+++ b/prepchef/packages/common/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@prep/common",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/packages/common/src/index.ts
+++ b/prepchef/packages/common/src/index.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const Money = z.object({ amount_cents: z.number().int(), currency: z.string().default('USD') });
+export type Money = z.infer<typeof Money>;
+
+export const BookingStatus = z.enum(['requested','awaiting_docs','payment_authorized','confirmed','active','completed','canceled','no_show','disputed']);
+export type BookingStatus = z.infer<typeof BookingStatus>;
+
+export const ApiError = (code: string, message: string, hint?: string) => ({ code, message, ...(hint?{hint}:{} )});

--- a/prepchef/packages/common/tsconfig.json
+++ b/prepchef/packages/common/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src" },
+  "include": ["src"]
+}

--- a/prepchef/packages/logger/package.json
+++ b/prepchef/packages/logger/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@prep/logger",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/packages/logger/src/index.ts
+++ b/prepchef/packages/logger/src/index.ts
@@ -1,0 +1,5 @@
+export const log = {
+  info: (...args: any[]) => console.log('[INFO]', ...args),
+  warn: (...args: any[]) => console.warn('[WARN]', ...args),
+  error: (...args: any[]) => console.error('[ERROR]', ...args)
+};

--- a/prepchef/packages/logger/tsconfig.json
+++ b/prepchef/packages/logger/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src" },
+  "include": ["src"]
+}

--- a/prepchef/packages/tsconfig/tsconfig.base.json
+++ b/prepchef/packages/tsconfig/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "types": ["node"]
+  }
+}

--- a/prepchef/scripts/codegen-stub.js
+++ b/prepchef/scripts/codegen-stub.js
@@ -1,0 +1,1 @@
+console.log('OpenAPI codegen stub. Replace with openapi-typescript / openapi-generator as needed.')

--- a/prepchef/services/access-svc/.env.example
+++ b/prepchef/services/access-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/access-svc/Dockerfile
+++ b/prepchef/services/access-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/access-svc/package.json
+++ b/prepchef/services/access-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/access-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/access-svc/src/api/access.ts
+++ b/prepchef/services/access-svc/src/api/access.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function (app: FastifyInstance) {
+  app.post('/access/provision', async (req, reply) => {
+    // TODO: integrate with vendor; emit event
+    return reply.send({ credentialId: 'cred_test_123', code: '123456' });
+  });
+  app.post('/access/revoke', async (req, reply) => {
+    return reply.send({ revoked: true });
+  });
+}

--- a/prepchef/services/access-svc/src/index.ts
+++ b/prepchef/services/access-svc/src/index.ts
@@ -1,0 +1,17 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'access-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'access-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('access-svc listening', port));
+import access from './api/access';
+app.register(access);

--- a/prepchef/services/access-svc/tsconfig.json
+++ b/prepchef/services/access-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/admin-svc/.env.example
+++ b/prepchef/services/admin-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/admin-svc/Dockerfile
+++ b/prepchef/services/admin-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/admin-svc/package.json
+++ b/prepchef/services/admin-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/admin-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/admin-svc/src/index.ts
+++ b/prepchef/services/admin-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'admin-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'admin-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('admin-svc listening', port));

--- a/prepchef/services/admin-svc/tsconfig.json
+++ b/prepchef/services/admin-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/audit-svc/.env.example
+++ b/prepchef/services/audit-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/audit-svc/Dockerfile
+++ b/prepchef/services/audit-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/audit-svc/package.json
+++ b/prepchef/services/audit-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/audit-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/audit-svc/src/index.ts
+++ b/prepchef/services/audit-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'audit-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'audit-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('audit-svc listening', port));

--- a/prepchef/services/audit-svc/tsconfig.json
+++ b/prepchef/services/audit-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/auth-svc/.env.example
+++ b/prepchef/services/auth-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/auth-svc/Dockerfile
+++ b/prepchef/services/auth-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/auth-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function (app: FastifyInstance) {
+  app.post('/auth/login', async (_req, reply) => {
+    // TODO: real JWT implementation
+    return reply.send({ token: 'dev.jwt.token' });
+  });
+}

--- a/prepchef/services/auth-svc/src/index.ts
+++ b/prepchef/services/auth-svc/src/index.ts
@@ -1,0 +1,17 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'auth-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'auth-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('auth-svc listening', port));
+import auth from './api/auth';
+app.register(auth);

--- a/prepchef/services/auth-svc/tsconfig.json
+++ b/prepchef/services/auth-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/availability-svc/.env.example
+++ b/prepchef/services/availability-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/availability-svc/Dockerfile
+++ b/prepchef/services/availability-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/availability-svc/package.json
+++ b/prepchef/services/availability-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/availability-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/availability-svc/src/index.ts
+++ b/prepchef/services/availability-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'availability-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'availability-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('availability-svc listening', port));

--- a/prepchef/services/availability-svc/tsconfig.json
+++ b/prepchef/services/availability-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/booking-svc/.env.example
+++ b/prepchef/services/booking-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/booking-svc/Dockerfile
+++ b/prepchef/services/booking-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/booking-svc/package.json
+++ b/prepchef/services/booking-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/booking-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/booking-svc/src/api/bookings.ts
+++ b/prepchef/services/booking-svc/src/api/bookings.ts
@@ -1,0 +1,13 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { ApiError } from '@prep/common';
+
+export default async function (app: FastifyInstance) {
+  const Body = z.object({ listing_id: z.string().uuid(), starts_at: z.string(), ends_at: z.string() });
+  app.post('/bookings', async (req, reply) => {
+    const parsed = Body.safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send(ApiError('PC-REQ-400','Invalid body'));
+    // TODO: call compliance, availability, pricing, payments
+    return reply.code(201).send({ booking_id: crypto.randomUUID(), payment_intent_id: 'pi_test_123' });
+  });
+}

--- a/prepchef/services/booking-svc/src/index.ts
+++ b/prepchef/services/booking-svc/src/index.ts
@@ -1,0 +1,17 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'booking-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'booking-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('booking-svc listening', port));
+import bookings from './api/bookings';
+app.register(bookings);

--- a/prepchef/services/booking-svc/tsconfig.json
+++ b/prepchef/services/booking-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/compliance-svc/.env.example
+++ b/prepchef/services/compliance-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/compliance-svc/Dockerfile
+++ b/prepchef/services/compliance-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/compliance-svc/package.json
+++ b/prepchef/services/compliance-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/compliance-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/compliance-svc/src/index.ts
+++ b/prepchef/services/compliance-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'compliance-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'compliance-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('compliance-svc listening', port));

--- a/prepchef/services/compliance-svc/tsconfig.json
+++ b/prepchef/services/compliance-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/listing-svc/.env.example
+++ b/prepchef/services/listing-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/listing-svc/Dockerfile
+++ b/prepchef/services/listing-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/listing-svc/package.json
+++ b/prepchef/services/listing-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/listing-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/listing-svc/src/index.ts
+++ b/prepchef/services/listing-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'listing-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'listing-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('listing-svc listening', port));

--- a/prepchef/services/listing-svc/tsconfig.json
+++ b/prepchef/services/listing-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/notif-svc/.env.example
+++ b/prepchef/services/notif-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/notif-svc/Dockerfile
+++ b/prepchef/services/notif-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/notif-svc/package.json
+++ b/prepchef/services/notif-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/notif-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/notif-svc/src/index.ts
+++ b/prepchef/services/notif-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'notif-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'notif-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('notif-svc listening', port));

--- a/prepchef/services/notif-svc/tsconfig.json
+++ b/prepchef/services/notif-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/services/payments-svc/.env.example
+++ b/prepchef/services/payments-svc/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+JWT_SECRET=dev-secret

--- a/prepchef/services/payments-svc/Dockerfile
+++ b/prepchef/services/payments-svc/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build
+CMD ["node","dist/index.js"]

--- a/prepchef/services/payments-svc/package.json
+++ b/prepchef/services/payments-svc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prep/payments-svc",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "lint": "echo 'lint stub'",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "fastify": "^4.28.1",
+    "fastify-cors": "^8.5.0",
+    "fastify-jwt": "^6.7.1",
+    "zod": "^3.23.8",
+    "undici": "^6.19.8",
+    "@prep/common": "1.0.0",
+    "@prep/logger": "1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/prepchef/services/payments-svc/src/index.ts
+++ b/prepchef/services/payments-svc/src/index.ts
@@ -1,0 +1,15 @@
+import Fastify from 'fastify';
+import cors from 'fastify-cors';
+import { log } from '@prep/logger';
+
+const app = Fastify({ logger: false });
+app.register(cors);
+
+app.get('/healthz', async () => ({ ok: true, svc: 'payments-svc' }));
+
+app.register(async function routes(instance) {
+  instance.get('/', async () => ({ name: 'payments-svc' }));
+});
+
+const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
+app.listen({ port }).then(() => log.info('payments-svc listening', port));

--- a/prepchef/services/payments-svc/tsconfig.json
+++ b/prepchef/services/payments-svc/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@prep/tsconfig/tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/prepchef/tests/e2e/README.md
+++ b/prepchef/tests/e2e/README.md
@@ -1,0 +1,2 @@
+# Playwright E2E stubs
+# Add scenarios per spec Appendix C.

--- a/prepchef/tests/k6/search.js
+++ b/prepchef/tests/k6/search.js
@@ -1,0 +1,7 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+export const options = { vus: 10, duration: '10s' };
+export default function () {
+  http.get('http://localhost:3000/healthz');
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add PrepChef monorepo skeleton with shared packages and service stubs
- include contracts, Terraform boilerplate, and CI workflow
- seed booking, access, and auth routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d67922fc4832cbc9e3ec319da38cf