### PR TITLE
feat: migrate services to @fastify/cors

### DIFF
--- a/prepchef/services/access-svc/package.json
+++ b/prepchef/services/access-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/access-svc/src/index.ts
+++ b/prepchef/services/access-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/admin-svc/package.json
+++ b/prepchef/services/admin-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/admin-svc/src/index.ts
+++ b/prepchef/services/admin-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/audit-svc/package.json
+++ b/prepchef/services/audit-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/audit-svc/src/index.ts
+++ b/prepchef/services/audit-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/auth-svc/src/index.ts
+++ b/prepchef/services/auth-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/availability-svc/package.json
+++ b/prepchef/services/availability-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/availability-svc/src/index.ts
+++ b/prepchef/services/availability-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/booking-svc/package.json
+++ b/prepchef/services/booking-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/booking-svc/src/index.ts
+++ b/prepchef/services/booking-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/compliance-svc/package.json
+++ b/prepchef/services/compliance-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/compliance-svc/src/index.ts
+++ b/prepchef/services/compliance-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/listing-svc/package.json
+++ b/prepchef/services/listing-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/listing-svc/src/index.ts
+++ b/prepchef/services/listing-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/notif-svc/package.json
+++ b/prepchef/services/notif-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/notif-svc/src/index.ts
+++ b/prepchef/services/notif-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });

--- a/prepchef/services/payments-svc/package.json
+++ b/prepchef/services/payments-svc/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-cors": "^8.5.0",
     "fastify-jwt": "^6.7.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",
-    "@prep/logger": "1.0.0"
+    "@prep/logger": "1.0.0",
+    "@fastify/cors": "^9.0.0"
   },
   "devDependencies": {
     "tsx": "^4.16.2",

--- a/prepchef/services/payments-svc/src/index.ts
+++ b/prepchef/services/payments-svc/src/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify';
-import cors from 'fastify-cors';
+import cors from '@fastify/cors';
 import { log } from '@prep/logger';
 
 const app = Fastify({ logger: false });


### PR DESCRIPTION
## Summary
- replace deprecated fastify-cors with @fastify/cors across all services
- update imports to use new plugin

## Testing
- `npm install --no-package-lock --ignore-scripts --no-audit --no-fund` (failed: 403 Forbidden)
- `PORT=4010 npx tsx services/access-svc/src/index.ts` (failed: E403)


------
https://chatgpt.com/codex/tasks/task_e_689d70714f54832c9d10eacd826d850c