### PR TITLE
feat: add access provider adapter and events

### DIFF
--- a/prepchef/services/access-svc/package.json
+++ b/prepchef/services/access-svc/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "echo 'lint stub'",
-    "test": "node -e \"console.log('no tests yet')\""
+    "test": "node --test --loader tsx src/tests/*.test.ts"
   },
   "dependencies": {
     "fastify": "^4.28.1",

--- a/prepchef/services/access-svc/src/adapters/accessProvider.ts
+++ b/prepchef/services/access-svc/src/adapters/accessProvider.ts
@@ -1,0 +1,34 @@
+export interface ProvisionParams {
+  userId: string;
+  resourceId: string;
+}
+
+export interface ProvisionResponse {
+  credentialId: string;
+  code: string;
+}
+
+export interface RevokeParams {
+  credentialId: string;
+}
+
+export interface RevokeResponse {
+  revoked: boolean;
+}
+
+export interface AccessProvider {
+  provision(params: ProvisionParams): Promise<ProvisionResponse>;
+  revoke(params: RevokeParams): Promise<RevokeResponse>;
+}
+
+class MockAccessProvider implements AccessProvider {
+  async provision(_params: ProvisionParams): Promise<ProvisionResponse> {
+    return { credentialId: 'cred_test_123', code: '123456' };
+  }
+
+  async revoke(_params: RevokeParams): Promise<RevokeResponse> {
+    return { revoked: true };
+  }
+}
+
+export const accessProvider: AccessProvider = new MockAccessProvider();

--- a/prepchef/services/access-svc/src/adapters/messageBus.ts
+++ b/prepchef/services/access-svc/src/adapters/messageBus.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+
+export const messageBus = new EventEmitter();

--- a/prepchef/services/access-svc/src/api/access.ts
+++ b/prepchef/services/access-svc/src/api/access.ts
@@ -1,11 +1,18 @@
 import { FastifyInstance } from 'fastify';
+import { accessProvider } from '../adapters/accessProvider';
+import { messageBus } from '../adapters/messageBus';
 
 export default async function (app: FastifyInstance) {
   app.post('/access/provision', async (req, reply) => {
-    // TODO: integrate with vendor; emit event
-    return reply.send({ credentialId: 'cred_test_123', code: '123456' });
+    const { userId, resourceId } = req.body as any;
+    const credential = await accessProvider.provision({ userId, resourceId });
+    messageBus.emit('access.provisioned', { userId, resourceId, ...credential });
+    return reply.send(credential);
   });
   app.post('/access/revoke', async (req, reply) => {
-    return reply.send({ revoked: true });
+    const { credentialId } = req.body as any;
+    const result = await accessProvider.revoke({ credentialId });
+    messageBus.emit('access.revoked', { credentialId });
+    return reply.send(result);
   });
 }

--- a/prepchef/services/access-svc/src/tests/access.test.ts
+++ b/prepchef/services/access-svc/src/tests/access.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import access from '../api/access';
+import { messageBus } from '../adapters/messageBus';
+
+test('provisions access and emits event', async () => {
+  const app = Fastify();
+  await app.register(access);
+
+  const events: any[] = [];
+  messageBus.once('access.provisioned', (payload) => events.push(payload));
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/access/provision',
+    payload: { userId: 'u1', resourceId: 'r1' }
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.equal(body.credentialId, 'cred_test_123');
+  assert.equal(events[0].credentialId, 'cred_test_123');
+});
+
+test('revokes access and emits event', async () => {
+  const app = Fastify();
+  await app.register(access);
+
+  const events: any[] = [];
+  messageBus.once('access.revoked', (payload) => events.push(payload));
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/access/revoke',
+    payload: { credentialId: 'cred_test_123' }
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.equal(body.revoked, true);
+  assert.equal(events[0].credentialId, 'cred_test_123');
+});


### PR DESCRIPTION
## Summary
- implement AccessProvider with mock provision/revoke
- emit access.provisioned and access.revoked events
- add tests for provision and revoke paths

## Testing
- `npm test` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689d70635728832cbb173ac319040d62