### PR TITLE
Invoke downstream services in booking flow

### DIFF
--- a/prepchef/services/booking-svc/package.json
+++ b/prepchef/services/booking-svc/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "echo 'lint stub'",
-    "test": "node -e \"console.log('no tests yet')\""
+    "test": "npx tsx --test src/tests/bookings.test.ts"
   },
   "dependencies": {
     "fastify": "^4.28.1",

--- a/prepchef/services/booking-svc/src/api/bookings.ts
+++ b/prepchef/services/booking-svc/src/api/bookings.ts
@@ -1,13 +1,33 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { ApiError } from '@prep/common';
+import { fetch } from 'undici';
 
 export default async function (app: FastifyInstance) {
   const Body = z.object({ listing_id: z.string().uuid(), starts_at: z.string(), ends_at: z.string() });
   app.post('/bookings', async (req, reply) => {
     const parsed = Body.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send(ApiError('PC-REQ-400','Invalid body'));
-    // TODO: call compliance, availability, pricing, payments
-    return reply.code(201).send({ booking_id: crypto.randomUUID(), payment_intent_id: 'pi_test_123' });
+    const { listing_id, starts_at, ends_at } = parsed.data;
+    try {
+      const comp = await fetch('http://compliance/check', { method: 'POST', body: JSON.stringify({ listing_id }) });
+      if (!comp.ok) return reply.code(412).send(ApiError('PC-COMP-412', 'Compliance check failed'));
+
+      const avail = await fetch('http://availability/check', { method: 'POST', body: JSON.stringify({ listing_id, starts_at, ends_at }) });
+      if (!avail.ok) return reply.code(412).send(ApiError('PC-AVAIL-412', 'Listing not available'));
+
+      const priceRes = await fetch('http://pricing/quote', { method: 'POST', body: JSON.stringify({ listing_id, starts_at, ends_at }) });
+      if (!priceRes.ok) return reply.code(412).send(ApiError('PC-PRICE-412', 'Unable to calculate price'));
+      const price = await priceRes.json();
+
+      const payRes = await fetch('http://payments/intents', { method: 'POST', body: JSON.stringify({ listing_id, amount: price.amount }) });
+      if (!payRes.ok) return reply.code(402).send(ApiError('PC-PAY-402', 'Payment failed'));
+      const payment = await payRes.json();
+
+      return reply.code(201).send({ booking_id: crypto.randomUUID(), payment_intent_id: payment.id });
+    } catch (err) {
+      app.log.error(err);
+      return reply.code(500).send(ApiError('PC-BOOK-500', 'Unexpected error'));
+    }
   });
 }

--- a/prepchef/services/booking-svc/src/tests/bookings.test.ts
+++ b/prepchef/services/booking-svc/src/tests/bookings.test.ts
@@ -1,0 +1,131 @@
+import { test } from 'node:test';
+import Fastify from 'fastify';
+import { MockAgent, setGlobalDispatcher } from 'undici';
+import { strict as assert } from 'node:assert';
+import bookings from '../api/bookings';
+
+function build() {
+  const app = Fastify();
+  app.register(bookings);
+  return app;
+}
+
+test('creates booking on success', async () => {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  agent.get('http://compliance').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://availability').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://pricing').intercept({ path: '/quote', method: 'POST' }).reply(200, { amount: 100 });
+  agent.get('http://payments').intercept({ path: '/intents', method: 'POST' }).reply(200, { id: 'pi_123' });
+
+  const app = build();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/bookings',
+    payload: {
+      listing_id: '00000000-0000-0000-0000-000000000001',
+      starts_at: '2020-01-01',
+      ends_at: '2020-01-02'
+    }
+  });
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.json().payment_intent_id, 'pi_123');
+  await app.close();
+  await agent.close();
+});
+
+test('maps compliance failure', async () => {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  agent.get('http://compliance').intercept({ path: '/check', method: 'POST' }).reply(412, {});
+
+  const app = build();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/bookings',
+    payload: {
+      listing_id: '00000000-0000-0000-0000-000000000001',
+      starts_at: '2020-01-01',
+      ends_at: '2020-01-02'
+    }
+  });
+  assert.equal(res.statusCode, 412);
+  assert.equal(res.json().code, 'PC-COMP-412');
+  await app.close();
+  await agent.close();
+});
+
+test('maps availability failure', async () => {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  agent.get('http://compliance').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://availability').intercept({ path: '/check', method: 'POST' }).reply(412, {});
+
+  const app = build();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/bookings',
+    payload: {
+      listing_id: '00000000-0000-0000-0000-000000000001',
+      starts_at: '2020-01-01',
+      ends_at: '2020-01-02'
+    }
+  });
+  assert.equal(res.statusCode, 412);
+  assert.equal(res.json().code, 'PC-AVAIL-412');
+  await app.close();
+  await agent.close();
+});
+
+test('maps pricing failure', async () => {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  agent.get('http://compliance').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://availability').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://pricing').intercept({ path: '/quote', method: 'POST' }).reply(412, {});
+
+  const app = build();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/bookings',
+    payload: {
+      listing_id: '00000000-0000-0000-0000-000000000001',
+      starts_at: '2020-01-01',
+      ends_at: '2020-01-02'
+    }
+  });
+  assert.equal(res.statusCode, 412);
+  assert.equal(res.json().code, 'PC-PRICE-412');
+  await app.close();
+  await agent.close();
+});
+
+test('maps payment failure', async () => {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  setGlobalDispatcher(agent);
+  agent.get('http://compliance').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://availability').intercept({ path: '/check', method: 'POST' }).reply(204, {});
+  agent.get('http://pricing').intercept({ path: '/quote', method: 'POST' }).reply(200, { amount: 100 });
+  agent.get('http://payments').intercept({ path: '/intents', method: 'POST' }).reply(402, {});
+
+  const app = build();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/bookings',
+    payload: {
+      listing_id: '00000000-0000-0000-0000-000000000001',
+      starts_at: '2020-01-01',
+      ends_at: '2020-01-02'
+    }
+  });
+  assert.equal(res.statusCode, 402);
+  assert.equal(res.json().code, 'PC-PAY-402');
+  await app.close();
+  await agent.close();
+});
+


### PR DESCRIPTION
## Summary
- Call compliance, availability, pricing, and payments services in booking endpoint
- Map downstream failures to canonical error codes and HTTP statuses
- Add integration tests covering downstream success and error scenarios

## Testing
- `npm test` *(fails: 403 Forbidden fetching tsx package)*

------
https://chatgpt.com/codex/tasks/task_e_689d7060e984832ca5836c95101c3c17