### PR TITLE
feat(auth): add jwt login and refresh with tests

### DIFF
--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "echo 'lint stub'",
-    "test": "node -e \"console.log('no tests yet')\""
+    "test": "node --test --loader tsx src/tests/*.test.ts"
   },
   "dependencies": {
     "fastify": "^4.28.1",

--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "@fastify/jwt": "^8.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import fastifyJwt from 'fastify-jwt';
+import fastifyJwt from '@fastify/jwt';
 
 declare module 'fastify' {
   interface FastifyInstance {

--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -1,8 +1,45 @@
 import { FastifyInstance } from 'fastify';
+import fastifyJwt from 'fastify-jwt';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    refreshTokens: Set<string>;
+  }
+}
 
 export default async function (app: FastifyInstance) {
-  app.post('/auth/login', async (_req, reply) => {
-    // TODO: real JWT implementation
-    return reply.send({ token: 'dev.jwt.token' });
+  app.register(fastifyJwt, { secret: 'supersecret' });
+  app.decorate('refreshTokens', new Set<string>());
+
+  app.post('/auth/login', async (req, reply) => {
+    const { username, password } = req.body as any;
+    if (username !== 'user' || password !== 'pass') {
+      return reply.code(401).send({ error: 'invalid credentials' });
+    }
+
+    const token = app.jwt.sign({ username }, { expiresIn: '15m' });
+    const refreshToken = app.jwt.sign({ username }, { expiresIn: '7d' });
+    app.refreshTokens.add(refreshToken);
+
+    return reply.send({ token, refreshToken });
+  });
+
+  app.post('/auth/refresh', async (req, reply) => {
+    const { refreshToken } = req.body as any;
+    if (!refreshToken || !app.refreshTokens.has(refreshToken)) {
+      return reply.code(401).send({ error: 'invalid refresh token' });
+    }
+
+    try {
+      const payload = app.jwt.verify(refreshToken) as any;
+      app.refreshTokens.delete(refreshToken);
+      const token = app.jwt.sign({ username: payload.username }, { expiresIn: '15m' });
+      const newRefreshToken = app.jwt.sign({ username: payload.username }, { expiresIn: '7d' });
+      app.refreshTokens.add(newRefreshToken);
+      return reply.send({ token, refreshToken: newRefreshToken });
+    } catch {
+      app.refreshTokens.delete(refreshToken);
+      return reply.code(401).send({ error: 'invalid refresh token' });
+    }
   });
 }

--- a/prepchef/services/auth-svc/src/tests/auth.test.ts
+++ b/prepchef/services/auth-svc/src/tests/auth.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import auth from '../api/auth';
+
+function build() {
+  const app = Fastify();
+  app.register(auth);
+  return app;
+}
+
+test('issues tokens on valid login', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'user', password: 'pass' }
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.ok(body.token);
+  assert.ok(body.refreshToken);
+  await app.close();
+});
+
+test('rejects invalid credentials', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'user', password: 'bad' }
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+
+test('refreshes token with valid refresh token', async () => {
+  const app = build();
+  await app.ready();
+
+  const loginRes = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'user', password: 'pass' }
+  });
+  const { refreshToken } = loginRes.json();
+
+  const refreshRes = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken }
+  });
+
+  assert.equal(refreshRes.statusCode, 200);
+  const refreshed = refreshRes.json();
+  assert.ok(refreshed.token);
+  assert.ok(refreshed.refreshToken);
+  await app.close();
+});
+
+test('rejects invalid refresh token', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken: 'bad' }
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+


### PR DESCRIPTION
## Summary
- implement credential validation with JWT and refresh token endpoints
- persist refresh tokens in-memory with error handling
- add unit tests for login success, failure, and refresh scenarios

## Testing
- `npm test` *(fails: Cannot find package 'tsx' / package installation fails with no matching version for fastify-jwt@^6.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d74563e10832cbe1609632e91774a