### PR TITLE
feat(auth): implement jwt login and refresh

### DIFF
--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "echo 'lint stub'",
-    "test": "node -e \"console.log('no tests yet')\""
+    "test": "node --test --loader tsx src/tests/auth.test.ts"
   },
   "dependencies": {
     "fastify": "^4.28.1",

--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -1,8 +1,70 @@
 import { FastifyInstance } from 'fastify';
+import fastifyJwt from 'fastify-jwt';
+import { z } from 'zod';
+
+interface User {
+  id: number;
+  password: string;
+}
+
+const users = new Map<string, User>([[
+  'demo',
+  { id: 1, password: 'password' },
+]]);
+
+export const refreshTokens = new Map<string, number>();
 
 export default async function (app: FastifyInstance) {
-  app.post('/auth/login', async (_req, reply) => {
-    // TODO: real JWT implementation
-    return reply.send({ token: 'dev.jwt.token' });
+  app.register(fastifyJwt, {
+    secret: process.env.JWT_SECRET || 'secret',
+  });
+
+  const credentialsSchema = z.object({
+    username: z.string(),
+    password: z.string(),
+  });
+
+  app.post('/auth/login', async (req, reply) => {
+    const parsed = credentialsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request' });
+    }
+
+    const { username, password } = parsed.data;
+    const user = users.get(username);
+    if (!user || user.password !== password) {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const token = app.jwt.sign({ sub: user.id }, { expiresIn: '15m' });
+    const refreshToken = app.jwt.sign(
+      { sub: user.id },
+      { expiresIn: '7d' },
+    );
+    refreshTokens.set(refreshToken, user.id);
+
+    return reply.send({ token, refreshToken });
+  });
+
+  const refreshSchema = z.object({ refreshToken: z.string() });
+
+  app.post('/auth/refresh', async (req, reply) => {
+    const parsed = refreshSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid request' });
+    }
+
+    const { refreshToken } = parsed.data;
+    if (!refreshTokens.has(refreshToken)) {
+      return reply.code(401).send({ error: 'Invalid refresh token' });
+    }
+
+    try {
+      const payload = app.jwt.verify<{ sub: number }>(refreshToken);
+      const token = app.jwt.sign({ sub: payload.sub }, { expiresIn: '15m' });
+      return reply.send({ token });
+    } catch {
+      return reply.code(401).send({ error: 'Invalid refresh token' });
+    }
   });
 }

--- a/prepchef/services/auth-svc/src/tests/auth.test.ts
+++ b/prepchef/services/auth-svc/src/tests/auth.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import auth, { refreshTokens } from '../api/auth';
+
+async function buildApp() {
+  const app = Fastify();
+  await app.register(auth);
+  return app;
+}
+
+test('login success returns tokens', async (t) => {
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+    refreshTokens.clear();
+  });
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'demo', password: 'password' },
+  });
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.ok(body.token);
+  assert.ok(body.refreshToken);
+});
+
+test('login failure returns 401', async (t) => {
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+    refreshTokens.clear();
+  });
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'demo', password: 'wrong' },
+  });
+  assert.equal(res.statusCode, 401);
+});
+
+test('refresh token flow', async (t) => {
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+    refreshTokens.clear();
+  });
+  const login = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'demo', password: 'password' },
+  });
+  const refreshToken = login.json().refreshToken;
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken },
+  });
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.ok(body.token);
+});


### PR DESCRIPTION
## Summary
- implement credential validation and JWT/refresh token issuing
- store refresh tokens and handle invalid credential errors
- add unit tests for login success, failure, and refresh flow

## Testing
- `npm install` *(fails: No matching version found for fastify-cors@^8.5.0)*
- `npm test` *(fails: command sh -c node --test --loader tsx src/tests/auth.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d71ff7214832c90e25297531cf21e