### PR TITLE
Register routes before server start

### DIFF
--- a/prepchef/services/access-svc/src/index.ts
+++ b/prepchef/services/access-svc/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cors from 'fastify-cors';
 import { log } from '@prep/logger';
+import access from './api/access';
 
 const app = Fastify({ logger: false });
 app.register(cors);
@@ -12,6 +13,5 @@ app.register(async function routes(instance) {
 });
 
 const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
-app.listen({ port }).then(() => log.info('access-svc listening', port));
-import access from './api/access';
 app.register(access);
+app.listen({ port }).then(() => log.info('access-svc listening', port));

--- a/prepchef/services/auth-svc/src/index.ts
+++ b/prepchef/services/auth-svc/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cors from 'fastify-cors';
 import { log } from '@prep/logger';
+import auth from './api/auth';
 
 const app = Fastify({ logger: false });
 app.register(cors);
@@ -12,6 +13,5 @@ app.register(async function routes(instance) {
 });
 
 const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
-app.listen({ port }).then(() => log.info('auth-svc listening', port));
-import auth from './api/auth';
 app.register(auth);
+app.listen({ port }).then(() => log.info('auth-svc listening', port));

--- a/prepchef/services/booking-svc/src/index.ts
+++ b/prepchef/services/booking-svc/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cors from 'fastify-cors';
 import { log } from '@prep/logger';
+import bookings from './api/bookings';
 
 const app = Fastify({ logger: false });
 app.register(cors);
@@ -12,6 +13,5 @@ app.register(async function routes(instance) {
 });
 
 const port = Number(process.env.PORT || 0) || (Math.floor(Math.random()*1000)+3000);
-app.listen({ port }).then(() => log.info('booking-svc listening', port));
-import bookings from './api/bookings';
 app.register(bookings);
+app.listen({ port }).then(() => log.info('booking-svc listening', port));


### PR DESCRIPTION
## Summary
- Ensure booking service registers API routes before server start
- Register access and auth routes prior to listening

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d70750f24832c9de5c44905010bfb