### PR TITLE
feat: generate API types

### DIFF
--- a/prepchef/.github/workflows/ci.yml
+++ b/prepchef/.github/workflows/ci.yml
@@ -9,4 +9,5 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run codegen
       - run: npm -ws run build

--- a/prepchef/package.json
+++ b/prepchef/package.json
@@ -11,6 +11,9 @@
     "dev": "echo 'Run with -w services/<svc>'",
     "lint": "npm -ws run lint",
     "test": "npm -ws run test --if-present",
-    "codegen": "node scripts/codegen-stub.js"
+    "codegen": "node scripts/codegen.js"
+  },
+  "devDependencies": {
+    "openapi-typescript": "^6.7.1"
   }
 }

--- a/prepchef/packages/generated/index.ts
+++ b/prepchef/packages/generated/index.ts
@@ -1,0 +1,1 @@
+// Generated types will be placed here

--- a/prepchef/packages/generated/package.json
+++ b/prepchef/packages/generated/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@prepchef/generated",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/prepchef/scripts/codegen-stub.js
+++ b/prepchef/scripts/codegen-stub.js
@@ -1,1 +1,0 @@
-console.log('OpenAPI codegen stub. Replace with openapi-typescript / openapi-generator as needed.')

--- a/prepchef/scripts/codegen.js
+++ b/prepchef/scripts/codegen.js
@@ -1,0 +1,18 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const root = path.resolve(__dirname, '..');
+const input = path.join(root, 'contracts', 'openapi.yaml');
+const outputDir = path.join(root, 'packages', 'generated');
+const outputFile = path.join(outputDir, 'index.ts');
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+try {
+  execSync(`npx openapi-typescript ${input} --output ${outputFile}`, { stdio: 'inherit' });
+  console.log('OpenAPI types generated at', outputFile);
+} catch (err) {
+  console.error('Failed to generate OpenAPI types:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add openapi-typescript code generation script
- emit OpenAPI types to shared package and run in CI

## Testing
- `npm run codegen` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openapi-typescript)*
- `npm test`
- `npm run lint` *(fails: Missing script: "lint" in some workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_689d706c80f8832ca67deccdd46128c0