### PR TITLE
feat(auth): add credential validation and refresh token rotation

### DIFF
--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -10,6 +10,12 @@ interface RefreshBody {
   refreshToken: string;
 }
 
+// Allow simple configuration of demo credentials.
+const VALID_USERNAME = process.env.AUTH_USERNAME || 'admin';
+const VALID_PASSWORD = process.env.AUTH_PASSWORD || 'secret';
+
+// In-memory persistence of refresh tokens. In a real service this
+// would be swapped for a database or cache.
 const refreshTokens = new Map<string, string>();
 
 export default async function (app: FastifyInstance) {
@@ -19,14 +25,16 @@ export default async function (app: FastifyInstance) {
 
   app.post<{ Body: LoginBody }>('/auth/login', async (req, reply) => {
     const { username, password } = req.body;
-    if (username !== 'admin' || password !== 'secret') {
+    if (username !== VALID_USERNAME || password !== VALID_PASSWORD) {
       return reply.code(401).send({ error: 'Invalid credentials' });
     }
+
     const token = await reply.jwtSign({ username });
     const refreshToken = await reply.jwtSign(
       { username },
       { expiresIn: '7d' }
     );
+
     refreshTokens.set(refreshToken, username);
     return reply.send({ token, refreshToken });
   });

--- a/prepchef/services/auth-svc/src/tests/auth.test.ts
+++ b/prepchef/services/auth-svc/src/tests/auth.test.ts
@@ -64,3 +64,28 @@ test('rejects invalid refresh token', async () => {
   });
   assert.equal(res.statusCode, 401);
 });
+
+test('cannot reuse refresh token after rotation', async () => {
+  const app = await buildApp();
+  const loginRes = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: validCreds,
+  });
+  const { refreshToken } = loginRes.json();
+
+  // First refresh succeeds and rotates the token
+  await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken },
+  });
+
+  // Second attempt with the same token should fail
+  const secondRes = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken },
+  });
+  assert.equal(secondRes.statusCode, 401);
+});


### PR DESCRIPTION
## Summary
- allow auth credentials to be configured via environment variables
- ensure refresh tokens rotate and add test for reuse prevention

## Testing
- `npm test` (fails: node --test --loader tsx src/tests/*.test.ts)
- `npm install` (fails: No matching version found for fastify-jwt@^6.7.1)


------
https://chatgpt.com/codex/tasks/task_e_689d79f988fc832ca32f581af5f02094