### PR TITLE
feat(auth): add jwt login and refresh with tests

### DIFF
--- a/prepchef/services/auth-svc/package.json
+++ b/prepchef/services/auth-svc/package.json
@@ -9,11 +9,11 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "lint": "echo 'lint stub'",
-    "test": "node -e \"console.log('no tests yet')\""
+    "test": "node --test --loader tsx src/tests/*.test.ts"
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "@fastify/jwt": "^8.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/auth-svc/src/api/auth.ts
+++ b/prepchef/services/auth-svc/src/api/auth.ts
@@ -1,8 +1,75 @@
 import { FastifyInstance } from 'fastify';
+import fastifyJwt from '@fastify/jwt';
 
-export default async function (app: FastifyInstance) {
-  app.post('/auth/login', async (_req, reply) => {
-    // TODO: real JWT implementation
-    return reply.send({ token: 'dev.jwt.token' });
+interface LoginBody {
+  username: string;
+  password: string;
+}
+
+interface RefreshBody {
+  refreshToken: string;
+}
+
+/**
+ * In-memory store for refresh tokens.
+ * Map<refreshToken, username>
+ * Replace with a durable store (DB/Redis) in production.
+ */
+const refreshTokens = new Map<string, string>();
+
+export default async function authRoutes(app: FastifyInstance) {
+  app.register(fastifyJwt, {
+    secret: process.env.JWT_SECRET || 'supersecret',
+  });
+
+  app.post<{ Body: LoginBody }>('/auth/login', async (req, reply) => {
+    const { username, password } = req.body;
+
+    // TODO: replace with real user lookup + password hash verify
+    if (username !== 'admin' || password !== 'secret') {
+      return reply.code(401).send({ error: 'Invalid credentials' });
+    }
+
+    const token = await reply.jwtSign({ username }, { expiresIn: '15m' });
+    const refreshToken = await reply.jwtSign(
+      { username },
+      { expiresIn: '7d' }
+    );
+
+    refreshTokens.set(refreshToken, username);
+
+    return reply.send({ token, refreshToken });
+  });
+
+  app.post<{ Body: RefreshBody }>('/auth/refresh', async (req, reply) => {
+    const { refreshToken } = req.body;
+
+    if (!refreshToken || !refreshTokens.has(refreshToken)) {
+      return reply.code(401).send({ error: 'Invalid refresh token' });
+    }
+
+    try {
+      const payload = await app.jwt.verify<{ username: string }>(refreshToken);
+
+      // Rotate the refresh token
+      refreshTokens.delete(refreshToken);
+
+      const token = await reply.jwtSign(
+        { username: payload.username },
+        { expiresIn: '15m' }
+      );
+      const newRefreshToken = await reply.jwtSign(
+        { username: payload.username },
+        { expiresIn: '7d' }
+      );
+
+      refreshTokens.set(newRefreshToken, payload.username);
+
+      return reply.send({ token, refreshToken: newRefreshToken });
+    } catch {
+      // Token invalid/expired — revoke if present and reject
+      refreshTokens.delete(refreshToken);
+      return reply.code(401).send({ error: 'Invalid refresh token' });
+    }
   });
 }

--- a/prepchef/services/auth-svc/src/tests/auth.test.ts
+++ b/prepchef/services/auth-svc/src/tests/auth.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Fastify from 'fastify';
+import auth from '../api/auth';
+
+function build() {
+  const app = Fastify();
+  app.register(auth);
+  return app;
+}
+
+test('issues tokens on valid login', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'admin', password: 'secret' }
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = res.json();
+  assert.ok(body.token);
+  assert.ok(body.refreshToken);
+  await app.close();
+});
+
+test('rejects invalid credentials', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'admin', password: 'bad' }
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+
+test('refreshes token with valid refresh token', async () => {
+  const app = build();
+  await app.ready();
+
+  const loginRes = await app.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { username: 'admin', password: 'secret' }
+  });
+  const { refreshToken } = loginRes.json();
+
+  const refreshRes = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken }
+  });
+
+  assert.equal(refreshRes.statusCode, 200);
+  const refreshed = refreshRes.json();
+  assert.ok(refreshed.token);
+  assert.ok(refreshed.refreshToken);
+  await app.close();
+});
+
+test('rejects invalid refresh token', async () => {
+  const app = build();
+  await app.ready();
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/auth/refresh',
+    payload: { refreshToken: 'bad' }
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+


### PR DESCRIPTION
## Summary
- implement credential validation with JWT and refresh token endpoints
- persist refresh tokens in-memory with error handling
- add unit tests for login success, failure, and refresh scenarios
- replace deprecated `fastify-jwt` dependency with `@fastify/jwt`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@fastify%2fjwt)*
- `npm test` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689d74563e10832cbe1609632e91774a