### PR TITLE
Add test coverage for core packages

### DIFF
--- a/tests/auto_projection_bot/test_auto_projection_bot_core.py
+++ b/tests/auto_projection_bot/test_auto_projection_bot_core.py
@@ -1,0 +1,8 @@
+from auto_projection_bot.core import AutoProjectionBot
+
+
+def test_methods_return_none():
+    bot = AutoProjectionBot()
+    assert bot.load_config('dummy_path') is None
+    assert bot.validate() is None
+    assert bot.generate_report() is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,3 +2,29 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from phase12.quiet_mode_core import QuietMode
+from phase12.bci_signal_router import BCIRouter
+from phase12.mobility_ui_kit import TwoButtonNavigator
+from phase12.ergonomic_kitchen_matcher import MobilityProfile
+
+
+@pytest.fixture
+def quiet_mode():
+    return QuietMode()
+
+
+@pytest.fixture
+def bci_router():
+    return BCIRouter()
+
+
+@pytest.fixture
+def navigator():
+    return TwoButtonNavigator(["opt1", "opt2", "opt3"])
+
+
+@pytest.fixture
+def sample_profile():
+    return MobilityProfile(reach_angle=45, max_transfer_height=32, fine_motor_control=True)

--- a/tests/gaap_ledger_porter/test_gaap_ledger_porter_core.py
+++ b/tests/gaap_ledger_porter/test_gaap_ledger_porter_core.py
@@ -1,0 +1,8 @@
+from gaap_ledger_porter.core import GAAPLedgerPorter
+
+
+def test_methods_return_none():
+    porter = GAAPLedgerPorter()
+    assert porter.load_config('dummy_path') is None
+    assert porter.validate({}) is None
+    assert porter.generate_report() is None

--- a/tests/hbs_model_validator/test_hbs_model_validator_core.py
+++ b/tests/hbs_model_validator/test_hbs_model_validator_core.py
@@ -1,0 +1,8 @@
+from hbs_model_validator.core import HBSModelValidator
+
+
+def test_methods_return_none():
+    validator = HBSModelValidator()
+    assert validator.load_config('dummy_path') is None
+    assert validator.validate({}) is None
+    assert validator.generate_report() is None

--- a/tests/phase12/test_bci_signal_router.py
+++ b/tests/phase12/test_bci_signal_router.py
@@ -1,0 +1,15 @@
+
+def test_bci_router_fallbacks(bci_router, capsys):
+    bci_router.handle_signal(None)
+    captured = capsys.readouterr()
+    assert bci_router.active_mode == "eye_tracking"
+    assert "BCI failed" in captured.out
+
+    bci_router.handle_signal(None)
+    captured = capsys.readouterr()
+    assert bci_router.active_mode == "voice"
+    assert "Eye-tracking failed" in captured.out
+
+    bci_router.handle_signal("ping")
+    captured = capsys.readouterr()
+    assert "Received signal in voice mode" in captured.out

--- a/tests/phase12/test_ergonomic_kitchen_matcher.py
+++ b/tests/phase12/test_ergonomic_kitchen_matcher.py
@@ -1,0 +1,12 @@
+from phase12.ergonomic_kitchen_matcher import MobilityProfile, match_kitchen
+
+
+def test_kitchen_match(sample_profile):
+    kitchen = match_kitchen(sample_profile)
+    assert kitchen is not None
+    assert kitchen.name == "Station A"
+
+
+def test_kitchen_no_match():
+    profile = MobilityProfile(reach_angle=45, max_transfer_height=20, fine_motor_control=True)
+    assert match_kitchen(profile) is None

--- a/tests/phase12/test_input_sense.py
+++ b/tests/phase12/test_input_sense.py
@@ -1,0 +1,14 @@
+from phase12.input_sense import SessionContext, detect_input_devices, configure_ui
+
+
+def test_detect_input_devices():
+    ctx = detect_input_devices()
+    assert "wheelchair" in ctx.input_mode
+    assert ctx.ui_mode == "gesture-free"
+
+
+def test_configure_ui(capsys):
+    ctx = SessionContext(input_mode=["voice"], ui_mode="default")
+    configure_ui(ctx)
+    captured = capsys.readouterr()
+    assert "Configuring UI for ['voice'] in default mode" in captured.out

--- a/tests/phase12/test_mobility_ui_kit.py
+++ b/tests/phase12/test_mobility_ui_kit.py
@@ -1,0 +1,18 @@
+
+def test_two_button_navigator(navigator, capsys):
+    assert navigator.confirm() == "opt1"
+
+    navigator.move_down()
+    captured = capsys.readouterr()
+    assert navigator.confirm() == "opt2"
+    assert "Focused on opt2" in captured.out
+
+    navigator.move_up()
+    captured = capsys.readouterr()
+    assert navigator.confirm() == "opt1"
+    assert "Focused on opt1" in captured.out
+
+    navigator.move_up()
+    captured = capsys.readouterr()
+    assert navigator.confirm() == "opt3"
+    assert "Focused on opt3" in captured.out

--- a/tests/phase12/test_quiet_mode_core.py
+++ b/tests/phase12/test_quiet_mode_core.py
@@ -1,0 +1,11 @@
+
+def test_quiet_mode_toggle(quiet_mode, capsys):
+    quiet_mode.toggle(True)
+    captured = capsys.readouterr()
+    assert quiet_mode.enabled is True
+    assert "Quiet mode activated" in captured.out
+
+    quiet_mode.toggle(False)
+    captured = capsys.readouterr()
+    assert quiet_mode.enabled is False
+    assert "Quiet mode deactivated" in captured.out


### PR DESCRIPTION
## Summary
- add reusable fixtures for Phase12 components
- add tests for auto_projection_bot, gaap_ledger_porter, and hbs_model_validator
- cover Phase12 quiet mode, BCI router, kitchen matcher, mobility UI kit, and input sensing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e15e72c38832c90cd56b1a393d3e6