### PR TITLE
Implement GAAP ledger validation and reporting with tests

### DIFF
--- a/gaap_ledger_porter/core.py
+++ b/gaap_ledger_porter/core.py
@@ -1,14 +1,82 @@
+import json
+from typing import Any, Dict, Iterable, Optional
+
+
 class GAAPLedgerPorter:
     """Handles export and import of GAAP compliant ledgers."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load ledger porting configuration."""
-        pass
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.ledger: Iterable[Dict[str, float]] = []
+        self.is_valid: bool = False
 
-    def validate(self, ledger) -> bool:
-        """Validate ledger entries against GAAP requirements."""
-        pass
+    def load_config(self, config_path: str) -> None:
+        """Load ledger porting configuration.
+
+        The configuration is expected to be a JSON document containing
+        ``import_path`` and optionally ``export_path`` values. When an
+        ``import_path`` is supplied the ledger data will be loaded from that
+        file immediately.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            self.config = json.load(handle)
+
+        import_path = self.config.get("import_path")
+        if import_path:
+            with open(import_path, "r", encoding="utf-8") as handle:
+                self.ledger = json.load(handle)
+
+    def validate(self, ledger: Optional[Iterable[Dict[str, float]]] = None) -> bool:
+        """Validate ledger entries against GAAP requirements.
+
+        Each ledger entry must contain numeric ``debit`` and ``credit`` keys and
+        the totals for each side must balance.
+        """
+
+        ledger_to_check = ledger if ledger is not None else self.ledger
+
+        total_debit = 0.0
+        total_credit = 0.0
+        for entry in ledger_to_check:
+            if not {"debit", "credit"}.issubset(entry):
+                self.is_valid = False
+                return False
+
+            debit = entry["debit"]
+            credit = entry["credit"]
+            if not isinstance(debit, (int, float)) or not isinstance(credit, (int, float)):
+                self.is_valid = False
+                return False
+
+            total_debit += float(debit)
+            total_credit += float(credit)
+
+        self.is_valid = total_debit == total_credit
+        return self.is_valid
 
     def generate_report(self) -> str:
-        """Produce a summary of ledger compliance."""
-        pass
+        """Produce a summary of ledger compliance.
+
+        The generated report is returned as a string. If an ``export_path`` is
+        configured it will also be written to that file.
+        """
+
+        if not self.ledger:
+            raise ValueError("Ledger data not loaded")
+
+        balanced = self.validate()
+
+        total_debit = sum(entry["debit"] for entry in self.ledger)
+        total_credit = sum(entry["credit"] for entry in self.ledger)
+        report = (
+            f"Total Debit: {total_debit}, Total Credit: {total_credit}, "
+            f"Balanced: {balanced}"
+        )
+
+        export_path = self.config.get("export_path")
+        if export_path:
+            with open(export_path, "w", encoding="utf-8") as handle:
+                handle.write(report)
+
+        return report

--- a/tests/gaap_ledger_porter/test_core.py
+++ b/tests/gaap_ledger_porter/test_core.py
@@ -1,0 +1,42 @@
+import json
+from gaap_ledger_porter.core import GAAPLedgerPorter
+
+
+def test_validate_balanced_ledger():
+    ledger = [
+        {"debit": 100, "credit": 100},
+        {"debit": 200, "credit": 200},
+    ]
+    porter = GAAPLedgerPorter()
+    assert porter.validate(ledger) is True
+
+
+def test_generate_report(tmp_path):
+    ledger = [{"debit": 150, "credit": 150}]
+    ledger_path = tmp_path / "ledger.json"
+    with open(ledger_path, "w", encoding="utf-8") as handle:
+        json.dump(ledger, handle)
+
+    export_path = tmp_path / "report.txt"
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({
+            "import_path": str(ledger_path),
+            "export_path": str(export_path),
+        }, handle)
+
+    porter = GAAPLedgerPorter()
+    porter.load_config(str(config_path))
+    assert porter.validate() is True
+    report = porter.generate_report()
+    assert "Balanced: True" in report
+    assert export_path.read_text() == report
+
+def test_validate_unbalanced_ledger():
+    ledger = [
+        {"debit": 100, "credit": 50},
+        {"debit": 25, "credit": 25},
+    ]
+    porter = GAAPLedgerPorter()
+    assert porter.validate(ledger) is False
+


### PR DESCRIPTION
## Summary
- add configuration loader that imports ledger data
- implement GAAP validation and reporting with export support
- cover GAAP validation and reporting with new tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e15de2f14832cbea348f5e1e4fe75