### PR TITLE
feat: implement projection core

### DIFF
--- a/auto_projection_bot/core.py
+++ b/auto_projection_bot/core.py
@@ -1,14 +1,51 @@
+import json
+from pathlib import Path
+
+
 class AutoProjectionBot:
     """Generates automated financial projections."""
 
+    def __init__(self) -> None:
+        self.config: dict | None = None
+
     def load_config(self, config_path: str) -> None:
         """Load projection parameters from configuration."""
-        pass
+        path = Path(config_path)
+        with path.open("r", encoding="utf-8") as f:
+            self.config = json.load(f)
 
     def validate(self) -> bool:
         """Validate projection assumptions and inputs."""
-        pass
+        if self.config is None:
+            raise ValueError("Configuration not loaded")
+
+        required = ["revenue", "expenses"]
+        for key in required:
+            if key not in self.config:
+                raise ValueError(f"Missing required field: {key}")
+            if not isinstance(self.config[key], (int, float)):
+                raise ValueError(f"Field {key} must be numeric")
+
+        growth = self.config.get("growth_rate", 0)
+        if growth is not None and not isinstance(growth, (int, float)):
+            raise ValueError("growth_rate must be numeric")
+
+        return True
 
     def generate_report(self) -> str:
         """Compile a projection summary for review."""
-        pass
+        self.validate()
+
+        revenue = float(self.config["revenue"])  # type: ignore[index]
+        expenses = float(self.config["expenses"])  # type: ignore[index]
+        growth_rate = float(self.config.get("growth_rate", 0))  # type: ignore[arg-type]
+
+        profit = revenue - expenses
+        projected_revenue = revenue * (1 + growth_rate)
+
+        return (
+            f"Revenue: {revenue}\n"
+            f"Expenses: {expenses}\n"
+            f"Profit: {profit}\n"
+            f"Projected Revenue (next period): {projected_revenue}"
+        )

--- a/tests/auto_projection_bot/test_core.py
+++ b/tests/auto_projection_bot/test_core.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+from auto_projection_bot.core import AutoProjectionBot
+
+
+def test_load_config(tmp_path):
+    data = {"revenue": 1000, "expenses": 400, "growth_rate": 0.1}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    bot = AutoProjectionBot()
+    bot.load_config(str(config_file))
+    assert bot.config == data
+
+
+def test_load_config_missing_file():
+    bot = AutoProjectionBot()
+    with pytest.raises(FileNotFoundError):
+        bot.load_config("missing.json")
+
+
+def test_validate_success(tmp_path):
+    data = {"revenue": 1000, "expenses": 400}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    bot = AutoProjectionBot()
+    bot.load_config(str(config_file))
+    assert bot.validate() is True
+
+
+def test_validate_missing_field(tmp_path):
+    data = {"revenue": 1000}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    bot = AutoProjectionBot()
+    bot.load_config(str(config_file))
+    with pytest.raises(ValueError):
+        bot.validate()
+
+
+def test_validate_type_error(tmp_path):
+    data = {"revenue": "1000", "expenses": 400}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    bot = AutoProjectionBot()
+    bot.load_config(str(config_file))
+    with pytest.raises(ValueError):
+        bot.validate()
+
+
+def test_generate_report(tmp_path):
+    data = {"revenue": 1000, "expenses": 400, "growth_rate": 0.1}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    bot = AutoProjectionBot()
+    bot.load_config(str(config_file))
+    report = bot.generate_report()
+    assert "Revenue: 1000.0" in report
+    assert "Expenses: 400.0" in report
+    assert "Profit: 600.0" in report
+    assert "Projected Revenue (next period): 1100.0" in report


### PR DESCRIPTION
## Summary
- implement configuration loading, validation, and report generation for AutoProjectionBot
- add unit tests for configuration and report generation edge cases

## Testing
- `pytest tests/auto_projection_bot/test_core.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e15db9418832c89661c96424a25df