### PR TITLE
Add configuration utilities

### DIFF
--- a/prep/__init__.py
+++ b/prep/__init__.py
@@ -1,5 +1,38 @@
-"""Prep package placeholder"""
+"""Prep package initialization utilities.
 
-def initialize():
-    """Placeholder initialize function."""
-    return True
+This module provides a simple helper for loading configuration data from a
+JSON file.  It replaces the previous placeholder that merely returned ``True``
+so that the package offers meaningful behaviour for consumers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def initialize(config_path: str) -> Dict[str, Any]:
+    """Load configuration from ``config_path``.
+
+    Parameters
+    ----------
+    config_path:
+        Path to a JSON configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed configuration dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the given path does not exist.
+    json.JSONDecodeError
+        If the file contents are not valid JSON.
+    """
+
+    path = Path(config_path)
+    with path.open("r", encoding="utf-8") as config_file:
+        return json.load(config_file)

--- a/prep/utility.py
+++ b/prep/utility.py
@@ -1,5 +1,33 @@
-"""Utility module placeholder."""
+"""Utility helpers for the :mod:`prep` package."""
 
-def util_func():
-    """Placeholder utility function."""
-    return True
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def util_func(config: Dict[str, Any], key: str, default: Any | None = None) -> Any:
+    """Retrieve ``key`` from ``config``.
+
+    Parameters
+    ----------
+    config:
+        Configuration dictionary to search.
+    key:
+        Key whose value should be returned.
+    default:
+        Fallback value if ``key`` is not present.  If ``None`` and the key is
+        missing a :class:`KeyError` is raised.
+
+    Returns
+    -------
+    Any
+        The located value or the provided ``default``.
+    """
+
+    if key in config:
+        return config[key]
+
+    if default is not None:
+        return default
+
+    raise KeyError(f"{key} not found in configuration")

--- a/tests/prep/test_init.py
+++ b/tests/prep/test_init.py
@@ -1,4 +1,11 @@
+import json
 import prep
 
-def test_initialize():
-    assert prep.initialize() is True
+
+def test_initialize(tmp_path):
+    config_data = {"option": "value"}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data))
+
+    result = prep.initialize(str(config_file))
+    assert result == config_data

--- a/tests/prep/test_utility.py
+++ b/tests/prep/test_utility.py
@@ -1,4 +1,25 @@
-from prep import utility
+import json
+import pytest
+from prep import initialize, utility
 
-def test_util_func():
-    assert utility.util_func() is True
+
+def create_config(tmp_path, data):
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+    return initialize(str(config_file))
+
+
+def test_util_func_returns_value(tmp_path):
+    config = create_config(tmp_path, {"answer": 42})
+    assert utility.util_func(config, "answer") == 42
+
+
+def test_util_func_uses_default(tmp_path):
+    config = create_config(tmp_path, {})
+    assert utility.util_func(config, "missing", default="fallback") == "fallback"
+
+
+def test_util_func_missing_key(tmp_path):
+    config = create_config(tmp_path, {})
+    with pytest.raises(KeyError):
+        utility.util_func(config, "missing")


### PR DESCRIPTION
## Summary
- implement config loading in `initialize`
- add key lookup helper `util_func`
- test config loading and key retrieval

## Testing
- `pytest tests/prep -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1ddab310832c8b330f07e1c0f5a1