### PR TITLE
Implement configuration loading utilities

### DIFF
--- a/prep/__init__.py
+++ b/prep/__init__.py
@@ -1,5 +1,30 @@
-"""Prep package placeholder"""
+"""Prep package initialization utilities."""
 
-def initialize():
-    """Placeholder initialize function."""
-    return True
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .utility import util_func
+
+
+def initialize(config_path: Path | str | None = None) -> dict:
+    """Initialize the Prep package by loading configuration data.
+
+    Parameters
+    ----------
+    config_path:
+        Optional path to a JSON configuration file. If ``None``, the
+        ``PREP_CONFIG`` environment variable is checked, defaulting to
+        ``'prep_config.json'`` if unset.
+
+    Returns
+    -------
+    dict
+        The loaded configuration mapping.
+    """
+
+    if config_path is None:
+        config_path = os.getenv("PREP_CONFIG", "prep_config.json")
+
+    return util_func(config_path)

--- a/prep/utility.py
+++ b/prep/utility.py
@@ -1,5 +1,35 @@
-"""Utility module placeholder."""
+"""Utility helpers for the Prep package."""
 
-def util_func():
-    """Placeholder utility function."""
-    return True
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def util_func(path: Path | str) -> dict:
+    """Load a JSON configuration file.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed configuration data.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    json.JSONDecodeError
+        If the file content is not valid JSON.
+    """
+
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Config file '{file_path}' not found")
+
+    with file_path.open("r", encoding="utf-8") as f:
+        return json.load(f)

--- a/tests/prep/test_init.py
+++ b/tests/prep/test_init.py
@@ -1,4 +1,25 @@
+"""Tests for the ``prep.initialize`` function."""
+
+import json
+
 import prep
 
-def test_initialize():
-    assert prep.initialize() is True
+def test_initialize_with_path(tmp_path):
+    """Configuration is loaded from an explicit path."""
+    config = {"mode": "test"}
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(config))
+
+    result = prep.initialize(cfg_file)
+    assert result == config
+
+
+def test_initialize_with_env_var(tmp_path, monkeypatch):
+    """Configuration path is resolved via ``PREP_CONFIG`` env var."""
+    config = {"mode": "env"}
+    cfg_file = tmp_path / "env_config.json"
+    cfg_file.write_text(json.dumps(config))
+    monkeypatch.setenv("PREP_CONFIG", str(cfg_file))
+
+    result = prep.initialize()
+    assert result == config

--- a/tests/prep/test_utility.py
+++ b/tests/prep/test_utility.py
@@ -1,4 +1,23 @@
+"""Tests for ``prep.utility`` functions."""
+
+import json
+
+import pytest
+
 from prep import utility
 
-def test_util_func():
-    assert utility.util_func() is True
+
+def test_util_func_loads_json(tmp_path):
+    """The utility correctly loads JSON configuration files."""
+    data = {"a": 1}
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps(data))
+
+    assert utility.util_func(cfg) == data
+
+
+def test_util_func_missing_file(tmp_path):
+    """A missing file results in ``FileNotFoundError``."""
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        utility.util_func(missing)


### PR DESCRIPTION
## Summary
- load JSON config files in `prep.util_func`
- allow `prep.initialize` to load config via path or `PREP_CONFIG` env var
- test config loading and error conditions

## Testing
- `pytest` *(fails: import file mismatch in unrelated tests)*
- `pytest tests/prep`


------
https://chatgpt.com/codex/tasks/task_e_689e1d9be138832c80a4d4465298f168