### PR TITLE
Add config loading utilities and tests for prep package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,35 @@ Thank you for your interest in contributing! This document will guide you throug
 
 ## Getting Started
 
-1. **Clone the Repository**
-2. **Install dependencies:** `npm install`
-3. **Create a `.env` file:** Copy `.env.example` and fill in secrets (never commit actual secrets).
-4. **Run the tests:** `npm test`
+### Python projects
+
+1. **Clone the repository.**
+2. **Install dependencies:** `pip install -e .`
+3. **Run the tests:** `pytest`
+
+### Node projects
+
+1. **Install dependencies:** `npm install`
+2. **Create a `.env` file:** Copy `.env.example` and fill in secrets (never commit actual secrets).
+3. **Run the tests:** `npm test`
+
+## Linting and Type Checks
+
+Shared configurations are provided for both ecosystems. Run these checks locally before submitting changes.
+
+### Python
+
+- Lint with [Ruff](https://github.com/astral-sh/ruff): `ruff .`
+- Type-check with [mypy](http://mypy-lang.org/): `mypy .`
+
+### Node
+
+- Lint with [ESLint](https://eslint.org/): `npx eslint .`
+- Type-check with the TypeScript compiler: `npx tsc --noEmit`
 
 ## Code Style
 
-- Use Prettier and ESLint (run `npm run lint` to check).
+- Use Prettier for formatting.
 - Typescript for backend/services, Python for some modules.
 - Write clear commit messages (e.g., `feat(auth): add JWT refresh tokens`).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ This repository hosts early prototypes for the Prep accessibility platform and r
    python -m venv .venv
    source .venv/bin/activate
    ```
-3. No Python package dependencies are currently pinned. Install any additional libraries as needed for specific modules.  
+3. Install Python dependencies defined in `pyproject.toml`:
+   ```bash
+   pip install -e .
+   ```
 4. For the `prepchef` subproject, ensure Node.js is installed and run:
    ```bash
    npm install

--- a/dol_reg_compliance_engine/core.py
+++ b/dol_reg_compliance_engine/core.py
@@ -1,14 +1,65 @@
+import json
+from typing import Any, Dict, Iterable, List
+
+
 class DOLRegComplianceEngine:
     """Ensures Department of Labor regulation compliance."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load compliance rules from configuration."""
-        pass
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.records: List[Dict[str, Any]] = []
+        self.is_valid: bool = False
 
-    def validate(self, data) -> bool:
+    def load_config(self, config_path: str) -> None:
+        """Load compliance rules from configuration.
+
+        Expected keys are ``minimum_wage`` (float) and ``max_hours_per_week``
+        (int). ``ValueError`` is raised for missing or malformed
+        configuration values.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+
+        min_wage = config.get("minimum_wage")
+        max_hours = config.get("max_hours_per_week")
+        if not isinstance(min_wage, (int, float)) or min_wage <= 0:
+            raise ValueError("minimum_wage missing or invalid")
+        if not isinstance(max_hours, int) or max_hours <= 0:
+            raise ValueError("max_hours_per_week missing or invalid")
+
+        self.config = config
+
+    def validate(self, data: Iterable[Dict[str, Any]]) -> bool:
         """Validate input data against DOL regulations."""
-        pass
+
+        if not self.config:
+            raise ValueError("Configuration not loaded")
+
+        min_wage = float(self.config["minimum_wage"])
+        max_hours = int(self.config["max_hours_per_week"])
+
+        for record in data:
+            wage = record.get("wage")
+            hours = record.get("hours_worked")
+            if wage is None or float(wage) < min_wage:
+                self.is_valid = False
+                return False
+            if hours is None or int(hours) > max_hours:
+                self.is_valid = False
+                return False
+
+        self.records = list(data)
+        self.is_valid = True
+        return True
 
     def generate_report(self) -> str:
         """Generate a compliance report."""
-        pass
+
+        if not self.records:
+            raise ValueError("No records validated")
+
+        return (
+            f"Records checked: {len(self.records)}, "
+            f"Compliant: {self.is_valid}"
+        )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+export default [
+  {
+    files: ["**/*.{js,ts}"],
+    languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+  },
+];

--- a/gdpr_ccpa_core/core.py
+++ b/gdpr_ccpa_core/core.py
@@ -1,14 +1,84 @@
+import json
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List
+
+
 class GDPRCCPACore:
     """Core utilities for GDPR and CCPA privacy compliance."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load privacy compliance settings from file."""
-        pass
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.records: List[Dict[str, Any]] = []
+        self.is_valid: bool = False
 
-    def validate(self, records) -> bool:
-        """Validate data handling practices."""
-        pass
+    def load_config(self, config_path: str) -> None:
+        """Load privacy compliance settings from file.
+
+        The configuration must contain ``allowed_regions`` (list of region
+        codes) and ``data_retention_days`` (positive integer). ``ValueError``
+        is raised if the configuration is missing or malformed.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+
+        allowed_regions = config.get("allowed_regions")
+        retention = config.get("data_retention_days")
+        if not isinstance(allowed_regions, list) or not allowed_regions:
+            raise ValueError("allowed_regions missing or invalid")
+        if not isinstance(retention, int) or retention <= 0:
+            raise ValueError("data_retention_days missing or invalid")
+
+        self.config = config
+
+    def validate(self, records: Iterable[Dict[str, Any]]) -> bool:
+        """Validate data handling practices.
+
+        Each record must include ``user_id``, ``region``, ``last_updated``
+        (ISO formatted string) and ``consent`` set to ``True``. Regions must be
+        listed in the configuration and the ``last_updated`` timestamp must not
+        exceed the configured retention period.
+        """
+
+        if not self.config:
+            raise ValueError("Configuration not loaded")
+
+        allowed_regions = set(self.config["allowed_regions"])
+        retention = timedelta(days=self.config["data_retention_days"])
+        now = datetime.utcnow()
+
+        for record in records:
+            if not record.get("consent"):
+                self.is_valid = False
+                return False
+
+            region = record.get("region")
+            if region not in allowed_regions:
+                self.is_valid = False
+                return False
+
+            last_updated_str = record.get("last_updated")
+            try:
+                last_updated = datetime.fromisoformat(last_updated_str)
+            except Exception:  # pragma: no cover - defensive
+                self.is_valid = False
+                return False
+
+            if now - last_updated > retention:
+                self.is_valid = False
+                return False
+
+        self.records = list(records)
+        self.is_valid = True
+        return True
 
     def generate_report(self) -> str:
         """Create a compliance assessment report."""
-        pass
+
+        if not self.records:
+            raise ValueError("No records validated")
+
+        return (
+            f"Records checked: {len(self.records)}, "
+            f"Compliant: {self.is_valid}"
+        )

--- a/multivoice_compliance_ui/core.py
+++ b/multivoice_compliance_ui/core.py
@@ -1,14 +1,62 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
 class MultiVoiceComplianceUI:
     """User interface for multi-language compliance workflows."""
 
+    def __init__(self) -> None:
+        self.config: Dict[str, object] = {}
+        self.actions: List[Dict[str, str]] = []
+
     def load_config(self, config_path: str) -> None:
-        """Load UI configuration parameters."""
-        pass
+        """Load UI configuration parameters.
+
+        Parameters
+        ----------
+        config_path:
+            Path to a JSON configuration file containing the keys
+            ``languages`` (list of supported language codes) and
+            ``rules`` (a mapping of rule names to descriptions).
+        """
+
+        with Path(config_path).open("r", encoding="utf-8") as fh:
+            self.config = json.load(fh)
 
     def validate(self) -> bool:
-        """Validate user actions for compliance."""
-        pass
+        """Validate user actions for compliance.
+
+        The configuration must be loaded and contain ``languages`` and
+        ``rules`` keys. Each recorded action must specify a ``language``
+        that exists in the configuration.
+        """
+
+        required_keys = {"languages", "rules"}
+        if not required_keys.issubset(self.config):
+            missing = required_keys - self.config.keys()
+            raise ValueError(f"Missing config keys: {missing}")
+
+        for action in self.actions:
+            language = action.get("language")
+            if language not in self.config["languages"]:
+                raise ValueError(f"Unsupported language: {language}")
+
+        return True
 
     def generate_report(self) -> str:
-        """Generate user compliance interaction reports."""
-        pass
+        """Generate user compliance interaction reports.
+
+        Returns
+        -------
+        str
+            JSON string summarising the session including the number of
+            actions recorded and the languages used.
+        """
+
+        languages_used = {a.get("language") for a in self.actions}
+        report = {
+            "total_actions": len(self.actions),
+            "languages_used": sorted(languages_used),
+        }
+        return json.dumps(report)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.10
+warn_return_any = True
+warn_unused_configs = True

--- a/prep/__init__.py
+++ b/prep/__init__.py
@@ -1,5 +1,30 @@
-"""Prep package placeholder"""
+"""Prep package initialization utilities."""
 
-def initialize():
-    """Placeholder initialize function."""
-    return True
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .utility import util_func
+
+
+def initialize(config_path: Path | str | None = None) -> dict:
+    """Initialize the Prep package by loading configuration data.
+
+    Parameters
+    ----------
+    config_path:
+        Optional path to a JSON configuration file. If ``None``, the
+        ``PREP_CONFIG`` environment variable is checked, defaulting to
+        ``'prep_config.json'`` if unset.
+
+    Returns
+    -------
+    dict
+        The loaded configuration mapping.
+    """
+
+    if config_path is None:
+        config_path = os.getenv("PREP_CONFIG", "prep_config.json")
+
+    return util_func(config_path)

--- a/prep/__init__.py
+++ b/prep/__init__.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any, Dict
 
 from .utility import util_func
 
+_CONFIG: Dict[str, Any] | None = None
 
-def initialize(config_path: Path | str | None = None) -> dict:
-    """Initialize the Prep package by loading configuration data.
+def initialize(config_path: Path | str | None = None) -> Dict[str, Any]:
+    """Load configuration data from a JSON file.
 
     Parameters
     ----------
@@ -21,10 +23,21 @@ def initialize(config_path: Path | str | None = None) -> dict:
     Returns
     -------
     dict
-        The loaded configuration mapping.
+        Parsed configuration dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the given path does not exist.
+    json.JSONDecodeError
+        If the file contents are not valid JSON.
     """
+    global _CONFIG
 
     if config_path is None:
+        if _CONFIG is not None:
+            return _CONFIG
         config_path = os.getenv("PREP_CONFIG", "prep_config.json")
 
-    return util_func(config_path)
+    _CONFIG = util_func(config_path)
+    return _CONFIG

--- a/prep/utility.py
+++ b/prep/utility.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, Dict
 
-
-def util_func(path: Path | str) -> dict:
+def util_func(path: Path | str) -> Dict[str, Any]:
     """Load a JSON configuration file.
 
     Parameters
@@ -26,7 +26,6 @@ def util_func(path: Path | str) -> dict:
     json.JSONDecodeError
         If the file content is not valid JSON.
     """
-
     file_path = Path(path)
     if not file_path.is_file():
         raise FileNotFoundError(f"Config file '{file_path}' not found")

--- a/prep/utility.py
+++ b/prep/utility.py
@@ -1,5 +1,35 @@
-"""Utility module placeholder."""
+"""Utility helpers for the Prep package."""
 
-def util_func():
-    """Placeholder utility function."""
-    return True
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def util_func(path: Path | str) -> dict:
+    """Load a JSON configuration file.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed configuration data.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    json.JSONDecodeError
+        If the file content is not valid JSON.
+    """
+
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Config file '{file_path}' not found")
+
+    with file_path.open("r", encoding="utf-8") as f:
+        return json.load(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prep"
+version = "0.1.0"
+description = "Prep prototypes"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pytest==8.4.1",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -ra --import-mode=importlib
+testpaths = tests/prep

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 addopts = -ra --import-mode=importlib
-testpaths = tests/prep
+testpaths = tests/auto_projection_bot \
+            tests/gaap_ledger_porter \
+            tests/hbs_model_validator \
+            tests/multivoice_compliance_ui \
+            tests/phase12 \
+            tests/prep

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -ra
+addopts = -ra --import-mode=importlib

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+line-length = 88
+target-version = "py310"

--- a/tests/auto_projection_bot/test_auto_projection_bot_core.py
+++ b/tests/auto_projection_bot/test_auto_projection_bot_core.py
@@ -1,8 +1,18 @@
+import json
+
 from auto_projection_bot.core import AutoProjectionBot
 
 
-def test_methods_return_none():
+def test_methods_run_end_to_end(tmp_path):
+    data = {"revenue": 1000, "expenses": 400, "growth_rate": 0.1}
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(data))
+
     bot = AutoProjectionBot()
-    assert bot.load_config('dummy_path') is None
-    assert bot.validate() is None
-    assert bot.generate_report() is None
+
+    assert bot.load_config(str(config_file)) is None
+    assert bot.validate() is True
+
+    report = bot.generate_report()
+    assert "Revenue: 1000.0" in report
+    assert "Expenses: 400.0" in report

--- a/tests/dol_reg_compliance_engine/test_core.py
+++ b/tests/dol_reg_compliance_engine/test_core.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from dol_reg_compliance_engine.core import DOLRegComplianceEngine
+
+
+def make_config(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"minimum_wage": 15.0, "max_hours_per_week": 40}, handle)
+    return config_path
+
+
+def test_validate_success(tmp_path):
+    config_path = make_config(tmp_path)
+    engine = DOLRegComplianceEngine()
+    engine.load_config(str(config_path))
+    data = [{"wage": 16.0, "hours_worked": 35}]
+    assert engine.validate(data) is True
+    report = engine.generate_report()
+    assert "Records checked: 1" in report
+
+
+def test_validate_failure_low_wage(tmp_path):
+    config_path = make_config(tmp_path)
+    engine = DOLRegComplianceEngine()
+    engine.load_config(str(config_path))
+    data = [{"wage": 10.0, "hours_worked": 35}]
+    assert engine.validate(data) is False
+
+
+def test_load_config_invalid(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"minimum_wage": -1}, handle)
+    engine = DOLRegComplianceEngine()
+    with pytest.raises(ValueError):
+        engine.load_config(str(config_path))
+

--- a/tests/gdpr_ccpa_core/test_core.py
+++ b/tests/gdpr_ccpa_core/test_core.py
@@ -1,0 +1,55 @@
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from gdpr_ccpa_core.core import GDPRCCPACore
+
+
+def make_config(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"allowed_regions": ["EU", "US"], "data_retention_days": 30}, handle)
+    return config_path
+
+
+def test_validate_success(tmp_path):
+    config_path = make_config(tmp_path)
+    core = GDPRCCPACore()
+    core.load_config(str(config_path))
+    records = [
+        {
+            "user_id": 1,
+            "region": "EU",
+            "last_updated": datetime.utcnow().isoformat(),
+            "consent": True,
+        }
+    ]
+    assert core.validate(records) is True
+    report = core.generate_report()
+    assert "Records checked: 1" in report
+
+
+def test_validate_failure_consent(tmp_path):
+    config_path = make_config(tmp_path)
+    core = GDPRCCPACore()
+    core.load_config(str(config_path))
+    records = [
+        {
+            "user_id": 1,
+            "region": "EU",
+            "last_updated": datetime.utcnow().isoformat(),
+            "consent": False,
+        }
+    ]
+    assert core.validate(records) is False
+
+
+def test_load_config_invalid(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"data_retention_days": 30}, handle)
+    core = GDPRCCPACore()
+    with pytest.raises(ValueError):
+        core.load_config(str(config_path))
+

--- a/tests/multivoice_compliance_ui/test_core.py
+++ b/tests/multivoice_compliance_ui/test_core.py
@@ -1,0 +1,23 @@
+import json
+from multivoice_compliance_ui.core import MultiVoiceComplianceUI
+
+
+def test_load_validate_and_report(tmp_path):
+    config = {
+        "languages": ["en", "es"],
+        "rules": {"greeting": "Must greet in selected language"},
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    ui = MultiVoiceComplianceUI()
+    ui.load_config(str(config_path))
+    ui.actions.append({"language": "en", "action": "greet"})
+
+    assert ui.validate() is True
+
+    report = json.loads(ui.generate_report())
+    assert report == {
+        "total_actions": 1,
+        "languages_used": ["en"],
+    }

--- a/tests/phase12/test_prep_assist_protocol.py
+++ b/tests/phase12/test_prep_assist_protocol.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from phase12 import prep_assist_protocol
+
+
+def test_send_command_connection_failure():
+    async def run():
+        with patch(
+            "phase12.prep_assist_protocol.websockets.connect", side_effect=OSError("fail")
+        ):
+            await prep_assist_protocol.send_command("ws://robot", {"a": 1})
+
+    with pytest.raises(ConnectionError):
+        asyncio.run(run())
+
+
+def test_send_command_send_failure():
+    mock_ws = AsyncMock()
+    mock_ws.send.side_effect = Exception("send")
+    connect_cm = AsyncMock()
+    connect_cm.__aenter__.return_value = mock_ws
+    connect_cm.__aexit__.return_value = False
+
+    async def run():
+        with patch("phase12.prep_assist_protocol.websockets.connect", return_value=connect_cm):
+            await prep_assist_protocol.send_command("ws://robot", {"a": 1})
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())
+
+
+def test_send_command_receive_failure():
+    mock_ws = AsyncMock()
+    mock_ws.send.return_value = None
+    mock_ws.recv.side_effect = Exception("recv")
+    connect_cm = AsyncMock()
+    connect_cm.__aenter__.return_value = mock_ws
+    connect_cm.__aexit__.return_value = False
+
+    async def run():
+        with patch("phase12.prep_assist_protocol.websockets.connect", return_value=connect_cm):
+            await prep_assist_protocol.send_command("ws://robot", {"a": 1})
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())

--- a/tests/prep/test_init.py
+++ b/tests/prep/test_init.py
@@ -1,4 +1,25 @@
+"""Tests for the ``prep.initialize`` function."""
+
+import json
+
 import prep
 
-def test_initialize():
-    assert prep.initialize() is True
+def test_initialize_with_path(tmp_path):
+    """Configuration is loaded from an explicit path."""
+    config = {"mode": "test"}
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(config))
+
+    result = prep.initialize(cfg_file)
+    assert result == config
+
+
+def test_initialize_with_env_var(tmp_path, monkeypatch):
+    """Configuration path is resolved via ``PREP_CONFIG`` env var."""
+    config = {"mode": "env"}
+    cfg_file = tmp_path / "env_config.json"
+    cfg_file.write_text(json.dumps(config))
+    monkeypatch.setenv("PREP_CONFIG", str(cfg_file))
+
+    result = prep.initialize()
+    assert result == config

--- a/tests/prep/test_init.py
+++ b/tests/prep/test_init.py
@@ -1,25 +1,44 @@
 """Tests for the ``prep.initialize`` function."""
 
 import json
+import importlib
 
+import pytest
 import prep
 
-def test_initialize_with_path(tmp_path):
+
+@pytest.fixture
+def fresh_prep():
+    """Reload the :mod:`prep` module to reset cached configuration."""
+    importlib.reload(prep)
+    return prep
+
+
+def test_initialize_with_path(tmp_path, fresh_prep):
     """Configuration is loaded from an explicit path."""
     config = {"mode": "test"}
     cfg_file = tmp_path / "config.json"
     cfg_file.write_text(json.dumps(config))
-
-    result = prep.initialize(cfg_file)
+    result = fresh_prep.initialize(cfg_file)
     assert result == config
 
 
-def test_initialize_with_env_var(tmp_path, monkeypatch):
+def test_initialize_with_env_var(tmp_path, monkeypatch, fresh_prep):
     """Configuration path is resolved via ``PREP_CONFIG`` env var."""
     config = {"mode": "env"}
     cfg_file = tmp_path / "env_config.json"
     cfg_file.write_text(json.dumps(config))
     monkeypatch.setenv("PREP_CONFIG", str(cfg_file))
-
-    result = prep.initialize()
+    result = fresh_prep.initialize()
     assert result == config
+
+
+def test_initialize_caches(tmp_path, fresh_prep):
+    """Repeated calls without path reuse cached data."""
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"a": 1}))
+    first = fresh_prep.initialize(cfg_file)
+    cfg_file.write_text(json.dumps({"a": 2}))
+    second = fresh_prep.initialize()
+    assert first == {"a": 1}
+    assert second == {"a": 1}

--- a/tests/prep/test_utility.py
+++ b/tests/prep/test_utility.py
@@ -12,7 +12,6 @@ def test_util_func_loads_json(tmp_path):
     data = {"a": 1}
     cfg = tmp_path / "config.json"
     cfg.write_text(json.dumps(data))
-
     assert utility.util_func(cfg) == data
 
 
@@ -21,3 +20,11 @@ def test_util_func_missing_file(tmp_path):
     missing = tmp_path / "missing.json"
     with pytest.raises(FileNotFoundError):
         utility.util_func(missing)
+
+
+def test_util_func_invalid_json(tmp_path):
+    """Malformed JSON raises ``JSONDecodeError``."""
+    cfg = tmp_path / "bad.json"
+    cfg.write_text("{bad json}")
+    with pytest.raises(json.JSONDecodeError):
+        utility.util_func(cfg)

--- a/tests/prep/test_utility.py
+++ b/tests/prep/test_utility.py
@@ -1,4 +1,23 @@
+"""Tests for ``prep.utility`` functions."""
+
+import json
+
+import pytest
+
 from prep import utility
 
-def test_util_func():
-    assert utility.util_func() is True
+
+def test_util_func_loads_json(tmp_path):
+    """The utility correctly loads JSON configuration files."""
+    data = {"a": 1}
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps(data))
+
+    assert utility.util_func(cfg) == data
+
+
+def test_util_func_missing_file(tmp_path):
+    """A missing file results in ``FileNotFoundError``."""
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        utility.util_func(missing)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Load configuration JSON in `initialize` via explicit path or `PREP_CONFIG` environment variable
- Parse and validate configuration files in `util_func`
- Add tests covering configuration loading and missing file errors
- Avoid pytest import conflicts by using `--import-mode=importlib`

## Testing
- `pytest tests/prep`
- `pytest` *(fails: tests auto_projection_bot, gaap_ledger_porter, phase12)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d9be138832c80a4d4465298f168