### PR TITLE
Implement basic multivoice compliance UI

### DIFF
--- a/multivoice_compliance_ui/core.py
+++ b/multivoice_compliance_ui/core.py
@@ -1,14 +1,62 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
 class MultiVoiceComplianceUI:
     """User interface for multi-language compliance workflows."""
 
+    def __init__(self) -> None:
+        self.config: Dict[str, object] = {}
+        self.actions: List[Dict[str, str]] = []
+
     def load_config(self, config_path: str) -> None:
-        """Load UI configuration parameters."""
-        pass
+        """Load UI configuration parameters.
+
+        Parameters
+        ----------
+        config_path:
+            Path to a JSON configuration file containing the keys
+            ``languages`` (list of supported language codes) and
+            ``rules`` (a mapping of rule names to descriptions).
+        """
+
+        with Path(config_path).open("r", encoding="utf-8") as fh:
+            self.config = json.load(fh)
 
     def validate(self) -> bool:
-        """Validate user actions for compliance."""
-        pass
+        """Validate user actions for compliance.
+
+        The configuration must be loaded and contain ``languages`` and
+        ``rules`` keys. Each recorded action must specify a ``language``
+        that exists in the configuration.
+        """
+
+        required_keys = {"languages", "rules"}
+        if not required_keys.issubset(self.config):
+            missing = required_keys - self.config.keys()
+            raise ValueError(f"Missing config keys: {missing}")
+
+        for action in self.actions:
+            language = action.get("language")
+            if language not in self.config["languages"]:
+                raise ValueError(f"Unsupported language: {language}")
+
+        return True
 
     def generate_report(self) -> str:
-        """Generate user compliance interaction reports."""
-        pass
+        """Generate user compliance interaction reports.
+
+        Returns
+        -------
+        str
+            JSON string summarising the session including the number of
+            actions recorded and the languages used.
+        """
+
+        languages_used = {a.get("language") for a in self.actions}
+        report = {
+            "total_actions": len(self.actions),
+            "languages_used": sorted(languages_used),
+        }
+        return json.dumps(report)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 addopts = -ra
-testpaths = tests/prep
+testpaths = tests/prep tests/multivoice_compliance_ui

--- a/tests/multivoice_compliance_ui/test_core.py
+++ b/tests/multivoice_compliance_ui/test_core.py
@@ -1,0 +1,23 @@
+import json
+from multivoice_compliance_ui.core import MultiVoiceComplianceUI
+
+
+def test_load_validate_and_report(tmp_path):
+    config = {
+        "languages": ["en", "es"],
+        "rules": {"greeting": "Must greet in selected language"},
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    ui = MultiVoiceComplianceUI()
+    ui.load_config(str(config_path))
+    ui.actions.append({"language": "en", "action": "greet"})
+
+    assert ui.validate() is True
+
+    report = json.loads(ui.generate_report())
+    assert report == {
+        "total_actions": 1,
+        "languages_used": ["en"],
+    }


### PR DESCRIPTION
## Summary
- flesh out MultivoiceComplianceUI with configuration loading, validation, and report generation
- add regression tests and include new testpath in pytest configuration

## Testing
- `pytest`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689e26ce7d10832cab64d04fecf28f74