### PR TITLE
Add pyproject and installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ This repository hosts early prototypes for the Prep accessibility platform and r
    python -m venv .venv
    source .venv/bin/activate
    ```
-3. No Python package dependencies are currently pinned. Install any additional libraries as needed for specific modules.  
+3. Install Python dependencies defined in `pyproject.toml`:
+   ```bash
+   pip install -e .
+   ```
 4. For the `prepchef` subproject, ensure Node.js is installed and run:
    ```bash
    npm install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prep"
+version = "0.1.0"
+description = "Prep prototypes"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pytest==8.4.1",
+]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with pinned `pytest` dependency
- document installation steps for Python dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4b39712c832ca1df0fdbf74f13ca