### PR TITLE
Expand pytest testpaths for broader test coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 addopts = -ra
-testpaths = tests/prep tests/multivoice_compliance_ui
+testpaths = tests/auto_projection_bot \
+            tests/gaap_ledger_porter \
+            tests/hbs_model_validator \
+            tests/multivoice_compliance_ui \
+            tests/phase12 \
+            tests/prep


### PR DESCRIPTION
## Summary
- include missing test directories in pytest.ini testpaths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e4c651ca4832c98d6618fe600b040