### PR TITLE
Implement compliance engines and add tests

### DIFF
--- a/dol_reg_compliance_engine/core.py
+++ b/dol_reg_compliance_engine/core.py
@@ -1,14 +1,65 @@
+import json
+from typing import Any, Dict, Iterable, List
+
+
 class DOLRegComplianceEngine:
     """Ensures Department of Labor regulation compliance."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load compliance rules from configuration."""
-        pass
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.records: List[Dict[str, Any]] = []
+        self.is_valid: bool = False
 
-    def validate(self, data) -> bool:
+    def load_config(self, config_path: str) -> None:
+        """Load compliance rules from configuration.
+
+        Expected keys are ``minimum_wage`` (float) and ``max_hours_per_week``
+        (int). ``ValueError`` is raised for missing or malformed
+        configuration values.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+
+        min_wage = config.get("minimum_wage")
+        max_hours = config.get("max_hours_per_week")
+        if not isinstance(min_wage, (int, float)) or min_wage <= 0:
+            raise ValueError("minimum_wage missing or invalid")
+        if not isinstance(max_hours, int) or max_hours <= 0:
+            raise ValueError("max_hours_per_week missing or invalid")
+
+        self.config = config
+
+    def validate(self, data: Iterable[Dict[str, Any]]) -> bool:
         """Validate input data against DOL regulations."""
-        pass
+
+        if not self.config:
+            raise ValueError("Configuration not loaded")
+
+        min_wage = float(self.config["minimum_wage"])
+        max_hours = int(self.config["max_hours_per_week"])
+
+        for record in data:
+            wage = record.get("wage")
+            hours = record.get("hours_worked")
+            if wage is None or float(wage) < min_wage:
+                self.is_valid = False
+                return False
+            if hours is None or int(hours) > max_hours:
+                self.is_valid = False
+                return False
+
+        self.records = list(data)
+        self.is_valid = True
+        return True
 
     def generate_report(self) -> str:
         """Generate a compliance report."""
-        pass
+
+        if not self.records:
+            raise ValueError("No records validated")
+
+        return (
+            f"Records checked: {len(self.records)}, "
+            f"Compliant: {self.is_valid}"
+        )

--- a/gdpr_ccpa_core/core.py
+++ b/gdpr_ccpa_core/core.py
@@ -1,14 +1,84 @@
+import json
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List
+
+
 class GDPRCCPACore:
     """Core utilities for GDPR and CCPA privacy compliance."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load privacy compliance settings from file."""
-        pass
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.records: List[Dict[str, Any]] = []
+        self.is_valid: bool = False
 
-    def validate(self, records) -> bool:
-        """Validate data handling practices."""
-        pass
+    def load_config(self, config_path: str) -> None:
+        """Load privacy compliance settings from file.
+
+        The configuration must contain ``allowed_regions`` (list of region
+        codes) and ``data_retention_days`` (positive integer). ``ValueError``
+        is raised if the configuration is missing or malformed.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+
+        allowed_regions = config.get("allowed_regions")
+        retention = config.get("data_retention_days")
+        if not isinstance(allowed_regions, list) or not allowed_regions:
+            raise ValueError("allowed_regions missing or invalid")
+        if not isinstance(retention, int) or retention <= 0:
+            raise ValueError("data_retention_days missing or invalid")
+
+        self.config = config
+
+    def validate(self, records: Iterable[Dict[str, Any]]) -> bool:
+        """Validate data handling practices.
+
+        Each record must include ``user_id``, ``region``, ``last_updated``
+        (ISO formatted string) and ``consent`` set to ``True``. Regions must be
+        listed in the configuration and the ``last_updated`` timestamp must not
+        exceed the configured retention period.
+        """
+
+        if not self.config:
+            raise ValueError("Configuration not loaded")
+
+        allowed_regions = set(self.config["allowed_regions"])
+        retention = timedelta(days=self.config["data_retention_days"])
+        now = datetime.utcnow()
+
+        for record in records:
+            if not record.get("consent"):
+                self.is_valid = False
+                return False
+
+            region = record.get("region")
+            if region not in allowed_regions:
+                self.is_valid = False
+                return False
+
+            last_updated_str = record.get("last_updated")
+            try:
+                last_updated = datetime.fromisoformat(last_updated_str)
+            except Exception:  # pragma: no cover - defensive
+                self.is_valid = False
+                return False
+
+            if now - last_updated > retention:
+                self.is_valid = False
+                return False
+
+        self.records = list(records)
+        self.is_valid = True
+        return True
 
     def generate_report(self) -> str:
         """Create a compliance assessment report."""
-        pass
+
+        if not self.records:
+            raise ValueError("No records validated")
+
+        return (
+            f"Records checked: {len(self.records)}, "
+            f"Compliant: {self.is_valid}"
+        )

--- a/tests/dol_reg_compliance_engine/test_core.py
+++ b/tests/dol_reg_compliance_engine/test_core.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from dol_reg_compliance_engine.core import DOLRegComplianceEngine
+
+
+def make_config(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"minimum_wage": 15.0, "max_hours_per_week": 40}, handle)
+    return config_path
+
+
+def test_validate_success(tmp_path):
+    config_path = make_config(tmp_path)
+    engine = DOLRegComplianceEngine()
+    engine.load_config(str(config_path))
+    data = [{"wage": 16.0, "hours_worked": 35}]
+    assert engine.validate(data) is True
+    report = engine.generate_report()
+    assert "Records checked: 1" in report
+
+
+def test_validate_failure_low_wage(tmp_path):
+    config_path = make_config(tmp_path)
+    engine = DOLRegComplianceEngine()
+    engine.load_config(str(config_path))
+    data = [{"wage": 10.0, "hours_worked": 35}]
+    assert engine.validate(data) is False
+
+
+def test_load_config_invalid(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"minimum_wage": -1}, handle)
+    engine = DOLRegComplianceEngine()
+    with pytest.raises(ValueError):
+        engine.load_config(str(config_path))
+

--- a/tests/gdpr_ccpa_core/test_core.py
+++ b/tests/gdpr_ccpa_core/test_core.py
@@ -1,0 +1,55 @@
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from gdpr_ccpa_core.core import GDPRCCPACore
+
+
+def make_config(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"allowed_regions": ["EU", "US"], "data_retention_days": 30}, handle)
+    return config_path
+
+
+def test_validate_success(tmp_path):
+    config_path = make_config(tmp_path)
+    core = GDPRCCPACore()
+    core.load_config(str(config_path))
+    records = [
+        {
+            "user_id": 1,
+            "region": "EU",
+            "last_updated": datetime.utcnow().isoformat(),
+            "consent": True,
+        }
+    ]
+    assert core.validate(records) is True
+    report = core.generate_report()
+    assert "Records checked: 1" in report
+
+
+def test_validate_failure_consent(tmp_path):
+    config_path = make_config(tmp_path)
+    core = GDPRCCPACore()
+    core.load_config(str(config_path))
+    records = [
+        {
+            "user_id": 1,
+            "region": "EU",
+            "last_updated": datetime.utcnow().isoformat(),
+            "consent": False,
+        }
+    ]
+    assert core.validate(records) is False
+
+
+def test_load_config_invalid(tmp_path):
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump({"data_retention_days": 30}, handle)
+    core = GDPRCCPACore()
+    with pytest.raises(ValueError):
+        core.load_config(str(config_path))
+


### PR DESCRIPTION
## Summary
- flesh out GDPR/CCPA core with configuration loading, validation, and reporting
- build DOL compliance engine for wage and hours checks
- add tests covering success and failure scenarios for both compliance modules

## Testing
- `pytest tests/gdpr_ccpa_core -q`
- `pytest tests/dol_reg_compliance_engine -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4c66a2e8832c9ef1fb9ee05f439a