### PR TITLE
docs: document language-specific workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,35 @@ Thank you for your interest in contributing! This document will guide you throug
 
 ## Getting Started
 
-1. **Clone the Repository**
-2. **Install dependencies:** `npm install`
-3. **Create a `.env` file:** Copy `.env.example` and fill in secrets (never commit actual secrets).
-4. **Run the tests:** `npm test`
+### Python projects
+
+1. **Clone the repository.**
+2. **Install dependencies:** `pip install -e .`
+3. **Run the tests:** `pytest`
+
+### Node projects
+
+1. **Install dependencies:** `npm install`
+2. **Create a `.env` file:** Copy `.env.example` and fill in secrets (never commit actual secrets).
+3. **Run the tests:** `npm test`
+
+## Linting and Type Checks
+
+Shared configurations are provided for both ecosystems. Run these checks locally before submitting changes.
+
+### Python
+
+- Lint with [Ruff](https://github.com/astral-sh/ruff): `ruff .`
+- Type-check with [mypy](http://mypy-lang.org/): `mypy .`
+
+### Node
+
+- Lint with [ESLint](https://eslint.org/): `npx eslint .`
+- Type-check with the TypeScript compiler: `npx tsc --noEmit`
 
 ## Code Style
 
-- Use Prettier and ESLint (run `npm run lint` to check).
+- Use Prettier for formatting.
 - Typescript for backend/services, Python for some modules.
 - Write clear commit messages (e.g., `feat(auth): add JWT refresh tokens`).
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+export default [
+  {
+    files: ["**/*.{js,ts}"],
+    languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+  },
+];

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.10
+warn_return_any = True
+warn_unused_configs = True

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+line-length = 88
+target-version = "py310"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- document separate Python and Node contribution workflows
- add shared linting and type-check config files

## Testing
- `ruff check .` *(fails: unused imports)*
- `mypy .` *(fails: duplicate module name)*
- `npx eslint .` *(fails: TypeScript parsing errors)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_689e4c6786dc832cabcd7b0c9a847d00