### PR TITLE
Handle timezone-aware records in GDPR core

### DIFF
--- a/gdpr_ccpa_core/core.py
+++ b/gdpr_ccpa_core/core.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List
 
 
@@ -45,8 +45,9 @@ class GDPRCCPACore:
 
         allowed_regions = set(self.config["allowed_regions"])
         retention = timedelta(days=self.config["data_retention_days"])
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
+        records = list(records)
         for record in records:
             if not record.get("consent"):
                 self.is_valid = False
@@ -59,7 +60,7 @@ class GDPRCCPACore:
 
             last_updated_str = record.get("last_updated")
             try:
-                last_updated = datetime.fromisoformat(last_updated_str)
+                last_updated = datetime.fromisoformat(last_updated_str).astimezone(timezone.utc)
             except Exception:  # pragma: no cover - defensive
                 self.is_valid = False
                 return False
@@ -68,7 +69,7 @@ class GDPRCCPACore:
                 self.is_valid = False
                 return False
 
-        self.records = list(records)
+        self.records = records
         self.is_valid = True
         return True
 

--- a/tests/gdpr_ccpa_core/test_core.py
+++ b/tests/gdpr_ccpa_core/test_core.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -21,7 +21,7 @@ def test_validate_success(tmp_path):
         {
             "user_id": 1,
             "region": "EU",
-            "last_updated": datetime.utcnow().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
             "consent": True,
         }
     ]
@@ -38,7 +38,7 @@ def test_validate_failure_consent(tmp_path):
         {
             "user_id": 1,
             "region": "EU",
-            "last_updated": datetime.utcnow().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
             "consent": False,
         }
     ]
@@ -52,4 +52,19 @@ def test_load_config_invalid(tmp_path):
     core = GDPRCCPACore()
     with pytest.raises(ValueError):
         core.load_config(str(config_path))
+
+
+def test_validate_generator_with_timezone(tmp_path):
+    config_path = make_config(tmp_path)
+    core = GDPRCCPACore()
+    core.load_config(str(config_path))
+    record = {
+        "user_id": 1,
+        "region": "EU",
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "consent": True,
+    }
+    records = (r for r in [record])
+    assert core.validate(records) is True
+    assert core.records == [record]
 


### PR DESCRIPTION
## Summary
- Ensure GDPR validator uses timezone-aware timestamps and lists
- Validate generator inputs with explicit time zones

## Testing
- `pytest tests/gdpr_ccpa_core/test_core.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6ac40e760832c955b800e962fe368