### PR TITLE
Fix generator validation and ensure record persistence

### DIFF
--- a/dol_reg_compliance_engine/core.py
+++ b/dol_reg_compliance_engine/core.py
@@ -36,10 +36,12 @@ class DOLRegComplianceEngine:
         if not self.config:
             raise ValueError("Configuration not loaded")
 
+        data_list = list(data)
+
         min_wage = float(self.config["minimum_wage"])
         max_hours = int(self.config["max_hours_per_week"])
 
-        for record in data:
+        for record in data_list:
             wage = record.get("wage")
             hours = record.get("hours_worked")
             if wage is None or float(wage) < min_wage:
@@ -49,7 +51,7 @@ class DOLRegComplianceEngine:
                 self.is_valid = False
                 return False
 
-        self.records = list(data)
+        self.records = data_list
         self.is_valid = True
         return True
 

--- a/tests/dol_reg_compliance_engine/test_core.py
+++ b/tests/dol_reg_compliance_engine/test_core.py
@@ -23,6 +23,21 @@ def test_validate_success(tmp_path):
     assert "Records checked: 1" in report
 
 
+def test_validate_generator_records_persist(tmp_path):
+    config_path = make_config(tmp_path)
+    engine = DOLRegComplianceEngine()
+    engine.load_config(str(config_path))
+
+    def record_gen():
+        yield {"wage": 16.0, "hours_worked": 35}
+        yield {"wage": 17.0, "hours_worked": 30}
+
+    assert engine.validate(record_gen()) is True
+    report = engine.generate_report()
+    assert "Records checked: 2" in report
+    assert len(engine.records) == 2
+
+
 def test_validate_failure_low_wage(tmp_path):
     config_path = make_config(tmp_path)
     engine = DOLRegComplianceEngine()


### PR DESCRIPTION
## Summary
- ensure validate casts input iterable to list once
- cover generator use case with test to verify records persist

## Testing
- `pytest tests/dol_reg_compliance_engine/test_core.py -q` *(failed: pytest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ac42dbb4832ca5710b707b001512