### PR TITLE
Implement HBS model validation logic and tests

### DIFF
--- a/hbs_model_validator/core.py
+++ b/hbs_model_validator/core.py
@@ -1,14 +1,71 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
 class HBSModelValidator:
     """Validates HBS models for consistency and compliance."""
 
-    def load_config(self, config_path: str) -> None:
-        """Load validation configuration from the specified path."""
-        pass
+    def __init__(self) -> None:
+        self.schema: Dict[str, str] = {}
+        self.required_fields: List[str] = []
+        self.errors: List[str] = []
 
-    def validate(self, model) -> bool:
-        """Run validation routines on the provided model."""
-        pass
+    def load_config(self, config_path: str) -> None:
+        """Load validation configuration from the specified path.
+
+        The configuration is expected to be a JSON file with two keys:
+        ``schema`` mapping field names to expected types and ``required``
+        listing fields that must be present.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+
+        self.schema = config.get("schema", {})
+        self.required_fields = config.get("required", [])
+
+    def validate(self, model: Dict[str, Any]) -> bool:
+        """Run validation routines on the provided model.
+
+        The model is expected to be a mapping. Required fields and type
+        checks are performed according to the previously loaded schema.
+        Returns ``True`` if no validation errors were found, otherwise
+        ``False``.
+        """
+
+        self.errors = []
+
+        # Check for required fields
+        for field in self.required_fields:
+            if field not in model:
+                self.errors.append(f"Missing required field: {field}")
+
+        # Type validation
+        type_map = {
+            "string": str,
+            "int": int,
+            "float": float,
+            "bool": bool,
+            "list": list,
+            "dict": dict,
+        }
+
+        for field, expected_type in self.schema.items():
+            if field in model and expected_type in type_map:
+                if not isinstance(model[field], type_map[expected_type]):
+                    self.errors.append(
+                        f"Field '{field}' expected type {expected_type}, got {type(model[field]).__name__}"
+                    )
+
+        return not self.errors
 
     def generate_report(self) -> str:
         """Create a report summarizing validation results."""
-        pass
+
+        if not self.errors:
+            return "Validation passed with 0 errors."
+
+        error_lines = "\n".join(f"- {msg}" for msg in self.errors)
+        return f"Validation failed with errors:\n{error_lines}"

--- a/tests/hbs_model_validator/test_hbs_model_validator_core.py
+++ b/tests/hbs_model_validator/test_hbs_model_validator_core.py
@@ -1,8 +1,45 @@
+import json
+
 from hbs_model_validator.core import HBSModelValidator
 
 
-def test_methods_return_none():
+def _write_config(tmp_path):
+    """Helper to create a simple schema configuration file."""
+    config = {
+        "schema": {"name": "string", "age": "int"},
+        "required": ["name", "age"],
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(config))
+    return path
+
+
+def test_load_config(tmp_path):
     validator = HBSModelValidator()
-    assert validator.load_config('dummy_path') is None
-    assert validator.validate({}) is None
-    assert validator.generate_report() is None
+    config_path = _write_config(tmp_path)
+    validator.load_config(str(config_path))
+
+    assert validator.schema == {"name": "string", "age": "int"}
+    assert validator.required_fields == ["name", "age"]
+
+
+def test_validate_success(tmp_path):
+    validator = HBSModelValidator()
+    validator.load_config(str(_write_config(tmp_path)))
+
+    model = {"name": "Alice", "age": 30}
+    assert validator.validate(model) is True
+    assert validator.errors == []
+    assert "passed" in validator.generate_report().lower()
+
+
+def test_validate_failure_and_report(tmp_path):
+    validator = HBSModelValidator()
+    validator.load_config(str(_write_config(tmp_path)))
+
+    model = {"name": "Bob", "age": "thirty"}
+    assert validator.validate(model) is False
+
+    report = validator.generate_report().lower()
+    assert "failed" in report
+    assert "expected type int" in report


### PR DESCRIPTION
## Summary
- implement config loading, model validation, and reporting in `HBSModelValidator`
- add tests covering config load, validation success/failure, and report output

## Testing
- `pytest tests/hbs_model_validator/test_hbs_model_validator_core.py -q`
- `ruff check hbs_model_validator tests/hbs_model_validator/test_hbs_model_validator_core.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac464200832c9a6d2dd5a599392d