### PR TITLE
Improve GAAP Ledger Porter test coverage

### DIFF
--- a/tests/gaap_ledger_porter/test_core.py
+++ b/tests/gaap_ledger_porter/test_core.py
@@ -1,5 +1,12 @@
 import json
+import pytest
 from gaap_ledger_porter.core import GAAPLedgerPorter
+
+
+def test_load_config_missing_file():
+    porter = GAAPLedgerPorter()
+    with pytest.raises(FileNotFoundError):
+        porter.load_config("missing.json")
 
 
 def test_validate_balanced_ledger():
@@ -39,4 +46,10 @@ def test_validate_unbalanced_ledger():
     ]
     porter = GAAPLedgerPorter()
     assert porter.validate(ledger) is False
+
+
+def test_generate_report_without_ledger():
+    porter = GAAPLedgerPorter()
+    with pytest.raises(ValueError):
+        porter.generate_report()
 

--- a/tests/gaap_ledger_porter/test_gaap_ledger_porter_core.py
+++ b/tests/gaap_ledger_porter/test_gaap_ledger_porter_core.py
@@ -1,8 +1,0 @@
-from gaap_ledger_porter.core import GAAPLedgerPorter
-
-
-def test_methods_return_none():
-    porter = GAAPLedgerPorter()
-    assert porter.load_config('dummy_path') is None
-    assert porter.validate({}) is None
-    assert porter.generate_report() is None


### PR DESCRIPTION
## Summary
- remove placeholder GAAP Ledger Porter tests
- validate missing config and empty ledger error paths

## Testing
- `ruff check tests/gaap_ledger_porter gaap_ledger_porter`
- `pytest tests/gaap_ledger_porter -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac486778832c8d81aa047344254a