### PR TITLE
Refactor modules for logging and controllable daemon

### DIFF
--- a/modules/haptic_router/router.py
+++ b/modules/haptic_router/router.py
@@ -1,3 +1,7 @@
+import logging
+from typing import Optional
+
+
 class HapticRouter:
     PATTERNS = {
         "start": [0.2],
@@ -5,9 +9,10 @@ class HapticRouter:
         "alert": [0.5],
     }
 
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.logger = logger or logging.getLogger(__name__)
+
     def route(self, mode: str):
-        pattern = self.PATTERNS.get(mode)
-        if not pattern:
-            pattern = []
-        print(f"Haptic pattern for {mode}: {pattern}")
+        pattern = self.PATTERNS.get(mode, [])
+        self.logger.info("Haptic pattern for %s: %s", mode, pattern)
         return pattern

--- a/modules/kitchen_safety_daemon/daemon.py
+++ b/modules/kitchen_safety_daemon/daemon.py
@@ -1,11 +1,23 @@
+import logging
 import time
+from typing import Optional
+
 
 class SafetyDaemon:
-    def __init__(self, check_interval: int = 60):
+    def __init__(self, check_interval: int = 60, logger: Optional[logging.Logger] = None):
         self.check_interval = check_interval
+        self.logger = logger or logging.getLogger(__name__)
+        self._stop = False
 
-    def monitor(self):
-        while True:
+    def stop(self) -> None:
+        self._stop = True
+
+    def monitor(self, iterations: Optional[int] = None) -> None:
+        count = 0
+        while not self._stop:
             # Placeholder for sensor checks
-            print("Performing safety check...")
+            self.logger.info("Performing safety check...")
             time.sleep(self.check_interval)
+            count += 1
+            if iterations is not None and count >= iterations:
+                break

--- a/modules/prep_sync_agent/sensor_logger.py
+++ b/modules/prep_sync_agent/sensor_logger.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from datetime import datetime
+from typing import Optional
 
 class PrepSyncAgent:
-    def __init__(self, kitchen_id: str):
+    def __init__(self, kitchen_id: str, logger: Optional[logging.Logger] = None):
         self.kitchen_id = kitchen_id
+        self.logger = logger or logging.getLogger(__name__)
 
     def log_event(self, event: str, value: str) -> str:
         data = {
@@ -13,5 +16,5 @@ class PrepSyncAgent:
             "timestamp": datetime.utcnow().isoformat() + "Z",
         }
         json_data = json.dumps(data)
-        print(json_data)
+        self.logger.info(json_data)
         return json_data

--- a/modules/voice_coach/coach.py
+++ b/modules/voice_coach/coach.py
@@ -1,6 +1,11 @@
+import logging
+from typing import Optional
+
+
 class VoiceCoach:
-    def __init__(self, tone: str = "neutral"):
+    def __init__(self, tone: str = "neutral", logger: Optional[logging.Logger] = None):
         self.tone = tone
+        self.logger = logger or logging.getLogger(__name__)
 
     def coach(self, message: str) -> str:
         if self.tone == "gentle":
@@ -10,5 +15,5 @@ class VoiceCoach:
         else:
             prefix = ""
         output = prefix + message
-        print(output)
+        self.logger.info(output)
         return output

--- a/tests/modules/test_haptic_router.py
+++ b/tests/modules/test_haptic_router.py
@@ -1,0 +1,13 @@
+import logging
+
+from modules.haptic_router.router import HapticRouter
+
+
+def test_route_logs_pattern(caplog):
+    logger = logging.getLogger("test.haptic_router")
+    router = HapticRouter(logger=logger)
+    with caplog.at_level(logging.INFO, logger="test.haptic_router"):
+        pattern = router.route("confirm")
+    assert pattern == [0.1, 0.1]
+    assert "Haptic pattern for confirm: [0.1, 0.1]" in caplog.text
+

--- a/tests/modules/test_kitchen_safety_daemon.py
+++ b/tests/modules/test_kitchen_safety_daemon.py
@@ -1,0 +1,27 @@
+import logging
+import threading
+import time
+
+from modules.kitchen_safety_daemon.daemon import SafetyDaemon
+
+
+def test_monitor_iterations(caplog):
+    logger = logging.getLogger("test.daemon.iter")
+    daemon = SafetyDaemon(check_interval=0, logger=logger)
+    with caplog.at_level(logging.INFO, logger="test.daemon.iter"):
+        daemon.monitor(iterations=2)
+    assert caplog.text.count("Performing safety check...") == 2
+
+
+def test_monitor_stop_flag(caplog):
+    logger = logging.getLogger("test.daemon.stop")
+    daemon = SafetyDaemon(check_interval=0.01, logger=logger)
+    with caplog.at_level(logging.INFO, logger="test.daemon.stop"):
+        thread = threading.Thread(target=daemon.monitor)
+        thread.start()
+        time.sleep(0.03)
+        daemon.stop()
+        thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert "Performing safety check..." in caplog.text
+

--- a/tests/modules/test_sensor_logger.py
+++ b/tests/modules/test_sensor_logger.py
@@ -1,0 +1,14 @@
+import json
+import logging
+
+from modules.prep_sync_agent.sensor_logger import PrepSyncAgent
+
+
+def test_log_event_logs_json(caplog):
+    logger = logging.getLogger("test.sensor_logger")
+    agent = PrepSyncAgent("k1", logger=logger)
+    with caplog.at_level(logging.INFO, logger="test.sensor_logger"):
+        result = agent.log_event("temp", "100")
+    assert json.loads(result)["event"] == "temp"
+    assert result in caplog.text
+

--- a/tests/modules/test_voice_coach.py
+++ b/tests/modules/test_voice_coach.py
@@ -1,0 +1,13 @@
+import logging
+
+from modules.voice_coach.coach import VoiceCoach
+
+
+def test_coach_logs_message(caplog):
+    logger = logging.getLogger("test.voice_coach")
+    coach = VoiceCoach(tone="gentle", logger=logger)
+    with caplog.at_level(logging.INFO, logger="test.voice_coach"):
+        result = coach.coach("Chop onions")
+    assert result == "Just a tip: Chop onions"
+    assert result in caplog.text
+


### PR DESCRIPTION
## Summary
- replace print statements with logging in several modules
- allow optional logger injection for testability
- make SafetyDaemon stoppable and support limited iterations
- add tests verifying logging output and daemon control

## Testing
- `pytest tests/modules -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac48b734832ca627346cb9f9fb9e