### PR TITLE
Validate TwoButtonNavigator items

### DIFF
--- a/phase12/mobility_ui_kit.py
+++ b/phase12/mobility_ui_kit.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 class TwoButtonNavigator:
     """Simple navigation model using up/confirm interactions."""
     def __init__(self, items):
+        if not items:
+            raise ValueError("items must be non-empty")
         self.items = items
         self.index = 0
 

--- a/tests/phase12/test_mobility_ui_kit.py
+++ b/tests/phase12/test_mobility_ui_kit.py
@@ -1,18 +1,27 @@
+import logging
+import pytest
+from phase12.mobility_ui_kit import TwoButtonNavigator
 
-def test_two_button_navigator(navigator, capsys):
-    assert navigator.confirm() == "opt1"
 
-    navigator.move_down()
-    captured = capsys.readouterr()
-    assert navigator.confirm() == "opt2"
-    assert "Focused on opt2" in captured.out
+def test_two_button_navigator(navigator, caplog):
+    with caplog.at_level(logging.INFO):
+        assert navigator.confirm() == "opt1"
 
-    navigator.move_up()
-    captured = capsys.readouterr()
-    assert navigator.confirm() == "opt1"
-    assert "Focused on opt1" in captured.out
+        navigator.move_down()
+        assert navigator.confirm() == "opt2"
+        assert "Focused on opt2" in caplog.text
 
-    navigator.move_up()
-    captured = capsys.readouterr()
-    assert navigator.confirm() == "opt3"
-    assert "Focused on opt3" in captured.out
+        caplog.clear()
+        navigator.move_up()
+        assert navigator.confirm() == "opt1"
+        assert "Focused on opt1" in caplog.text
+
+        caplog.clear()
+        navigator.move_up()
+        assert navigator.confirm() == "opt3"
+        assert "Focused on opt3" in caplog.text
+
+
+def test_two_button_navigator_rejects_empty_list():
+    with pytest.raises(ValueError):
+        TwoButtonNavigator([])


### PR DESCRIPTION
## Summary
- ensure `TwoButtonNavigator` raises `ValueError` when initialized with an empty list
- add tests verifying empty item lists are rejected and update navigator logging test

## Testing
- `ruff check phase12/mobility_ui_kit.py tests/phase12/test_mobility_ui_kit.py`
- `pytest tests/phase12/test_mobility_ui_kit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac4a4744832c8c106bcdeff2e106