### PR TITLE
Raise error for empty navigator items

### DIFF
--- a/phase12/mobility_ui_kit.py
+++ b/phase12/mobility_ui_kit.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 class TwoButtonNavigator:
     """Simple navigation model using up/confirm interactions."""
     def __init__(self, items):
+        if not items:
+            raise ValueError("items cannot be empty")
         self.items = items
         self.index = 0
 

--- a/tests/phase12/test_mobility_ui_kit.py
+++ b/tests/phase12/test_mobility_ui_kit.py
@@ -1,18 +1,30 @@
 
-def test_two_button_navigator(navigator, capsys):
+import logging
+import pytest
+from phase12 import mobility_ui_kit
+
+
+def test_two_button_navigator(navigator, caplog):
     assert navigator.confirm() == "opt1"
 
-    navigator.move_down()
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        navigator.move_down()
     assert navigator.confirm() == "opt2"
-    assert "Focused on opt2" in captured.out
+    assert "Focused on opt2" in caplog.text
+    caplog.clear()
 
-    navigator.move_up()
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        navigator.move_up()
     assert navigator.confirm() == "opt1"
-    assert "Focused on opt1" in captured.out
+    assert "Focused on opt1" in caplog.text
+    caplog.clear()
 
-    navigator.move_up()
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        navigator.move_up()
     assert navigator.confirm() == "opt3"
-    assert "Focused on opt3" in captured.out
+    assert "Focused on opt3" in caplog.text
+
+
+def test_two_button_navigator_rejects_empty_items():
+    with pytest.raises(ValueError):
+        mobility_ui_kit.TwoButtonNavigator([])


### PR DESCRIPTION
## Summary
- validate `TwoButtonNavigator` items and reject empty lists
- test that `TwoButtonNavigator` constructor raises `ValueError` when given no items

## Testing
- `pytest tests/phase12/test_mobility_ui_kit.py`
- `pytest tests/phase12` *(fails: test_configure_ui, test_quiet_mode_toggle)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ae018a9c832cb764270d2da50b74