### PR TITLE
Implement LSE impact simulator core functionality and tests

### DIFF
--- a/lse_impact_simulator/core.py
+++ b/lse_impact_simulator/core.py
@@ -1,14 +1,84 @@
+import json
+from typing import Any, Dict
+
+
 class LSEImpactSimulator:
     """Simulates impacts for the London Stock Exchange environment."""
 
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+        self.is_valid: bool = False
+
     def load_config(self, config_path: str) -> None:
-        """Load simulation configuration parameters."""
-        pass
+        """Load simulation configuration parameters.
+
+        Expected schema::
+
+            {
+                "market": str,
+                "volatility": float,
+                "duration": int,
+            }
+
+        ``volatility`` must be a non-negative value representing the expected
+        daily volatility percentage and ``duration`` must be a positive number
+        of trading days.
+        """
+
+        with open(config_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+
+        schema = {
+            "market": str,
+            "volatility": (int, float),
+            "duration": int,
+        }
+
+        for key, expected_type in schema.items():
+            if key not in data:
+                raise ValueError(f"Missing required config key: {key}")
+            if not isinstance(data[key], expected_type):
+                raise TypeError(f"Invalid type for {key}: expected {expected_type}")
+
+        self.config = data
 
     def validate(self) -> bool:
         """Validate scenario setup prior to simulation."""
-        pass
+
+        if not self.config:
+            self.is_valid = False
+            return False
+
+        market = self.config.get("market")
+        volatility = self.config.get("volatility")
+        duration = self.config.get("duration")
+
+        if not isinstance(market, str) or not market.strip():
+            self.is_valid = False
+            return False
+
+        if not isinstance(volatility, (int, float)) or volatility < 0:
+            self.is_valid = False
+            return False
+
+        if not isinstance(duration, int) or duration <= 0:
+            self.is_valid = False
+            return False
+
+        self.is_valid = True
+        return True
 
     def generate_report(self) -> str:
         """Report outcomes from the simulation run."""
-        pass
+
+        if not self.config:
+            raise ValueError("Configuration not loaded")
+
+        valid = self.validate()
+
+        return (
+            f"Market: {self.config['market']}, "
+            f"Volatility: {self.config['volatility']}, "
+            f"Duration: {self.config['duration']}, "
+            f"Valid: {valid}"
+        )

--- a/tests/lse_impact_simulator/test_core.py
+++ b/tests/lse_impact_simulator/test_core.py
@@ -1,0 +1,52 @@
+import json
+import pytest
+
+from lse_impact_simulator.core import LSEImpactSimulator
+
+
+def _write_config(tmp_path, data=None):
+    if data is None:
+        data = {"market": "LSE", "volatility": 0.2, "duration": 5}
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+    return config_path
+
+
+def test_load_config(tmp_path):
+    config_path = _write_config(tmp_path)
+    simulator = LSEImpactSimulator()
+    simulator.load_config(str(config_path))
+    assert simulator.config["market"] == "LSE"
+
+
+def test_load_config_missing_key(tmp_path):
+    config_path = _write_config(tmp_path, {"market": "LSE", "volatility": 0.2})
+    simulator = LSEImpactSimulator()
+    with pytest.raises(ValueError):
+        simulator.load_config(str(config_path))
+
+
+def test_validate(tmp_path):
+    simulator = LSEImpactSimulator()
+    config_path = _write_config(tmp_path)
+    simulator.load_config(str(config_path))
+    assert simulator.validate() is True
+    simulator.config["duration"] = 0
+    assert simulator.validate() is False
+
+
+def test_generate_report(tmp_path):
+    simulator = LSEImpactSimulator()
+    config_path = _write_config(tmp_path)
+    simulator.load_config(str(config_path))
+    report = simulator.generate_report()
+    assert "Market: LSE" in report
+    assert "Valid: True" in report
+
+
+def test_generate_report_without_config():
+    simulator = LSEImpactSimulator()
+    with pytest.raises(ValueError):
+        simulator.generate_report()
+


### PR DESCRIPTION
## Summary
- add configuration parsing, validation, and reporting to `LSEImpactSimulator`
- cover simulator methods with unit tests

## Testing
- `python -m pytest tests/lse_impact_simulator/test_core.py -q`
- `ruff check lse_impact_simulator tests/lse_impact_simulator`


------
https://chatgpt.com/codex/tasks/task_e_68a80640be94832cac511a5c41e394ad