### PR TITLE
feat: add async monitor with pluggable sleep

### DIFF
--- a/modules/kitchen_safety_daemon/daemon.py
+++ b/modules/kitchen_safety_daemon/daemon.py
@@ -1,23 +1,35 @@
+import asyncio
 import logging
 import time
-from typing import Optional
+from typing import Awaitable, Callable, Optional
+
+
+async def _default_sleep(delay: float) -> None:
+    """Default sleep function using ``time.sleep`` in a thread."""
+    await asyncio.to_thread(time.sleep, delay)
 
 
 class SafetyDaemon:
-    def __init__(self, check_interval: int = 60, logger: Optional[logging.Logger] = None):
+    def __init__(
+        self,
+        check_interval: int = 60,
+        logger: Optional[logging.Logger] = None,
+        sleep_fn: Callable[[float], Awaitable[None]] = _default_sleep,
+    ):
         self.check_interval = check_interval
         self.logger = logger or logging.getLogger(__name__)
         self._stop = False
+        self.sleep_fn = sleep_fn
 
     def stop(self) -> None:
         self._stop = True
 
-    def monitor(self, iterations: Optional[int] = None) -> None:
+    async def monitor(self, iterations: Optional[int] = None) -> None:
         count = 0
         while not self._stop:
             # Placeholder for sensor checks
             self.logger.info("Performing safety check...")
-            time.sleep(self.check_interval)
+            await self.sleep_fn(self.check_interval)
             count += 1
             if iterations is not None and count >= iterations:
                 break

--- a/tests/modules/test_kitchen_safety_daemon.py
+++ b/tests/modules/test_kitchen_safety_daemon.py
@@ -1,27 +1,36 @@
+import asyncio
 import logging
-import threading
-import time
 
 from modules.kitchen_safety_daemon.daemon import SafetyDaemon
 
 
 def test_monitor_iterations(caplog):
-    logger = logging.getLogger("test.daemon.iter")
-    daemon = SafetyDaemon(check_interval=0, logger=logger)
-    with caplog.at_level(logging.INFO, logger="test.daemon.iter"):
-        daemon.monitor(iterations=2)
+    async def fast_sleep(_: float) -> None:
+        pass
+
+    async def run() -> None:
+        logger = logging.getLogger("test.daemon.iter")
+        daemon = SafetyDaemon(check_interval=0, logger=logger, sleep_fn=fast_sleep)
+        with caplog.at_level(logging.INFO, logger="test.daemon.iter"):
+            await daemon.monitor(iterations=2)
+
+    asyncio.run(run())
     assert caplog.text.count("Performing safety check...") == 2
 
 
 def test_monitor_stop_flag(caplog):
-    logger = logging.getLogger("test.daemon.stop")
-    daemon = SafetyDaemon(check_interval=0.01, logger=logger)
-    with caplog.at_level(logging.INFO, logger="test.daemon.stop"):
-        thread = threading.Thread(target=daemon.monitor)
-        thread.start()
-        time.sleep(0.03)
-        daemon.stop()
-        thread.join(timeout=1)
-    assert not thread.is_alive()
+    async def fast_sleep(_: float) -> None:
+        await asyncio.sleep(0)
+
+    async def run() -> None:
+        logger = logging.getLogger("test.daemon.stop")
+        daemon = SafetyDaemon(check_interval=0.01, logger=logger, sleep_fn=fast_sleep)
+        with caplog.at_level(logging.INFO, logger="test.daemon.stop"):
+            task = asyncio.create_task(daemon.monitor())
+            await asyncio.sleep(0)  # allow the monitor to start
+            daemon.stop()
+            await task
+
+    asyncio.run(run())
     assert "Performing safety check..." in caplog.text
 


### PR DESCRIPTION
## Summary
- add pluggable sleep_fn to SafetyDaemon with async monitor
- use injectable sleep in tests for faster runtime

## Testing
- `pytest tests/modules/test_kitchen_safety_daemon.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8075585b0832c894e92765f0a029b