### PR TITLE
Add configurable LSE impact simulator with validation and reporting

### DIFF
--- a/lse_impact_simulator/core.py
+++ b/lse_impact_simulator/core.py
@@ -1,14 +1,56 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # pragma: no cover - exercised via tests
+    import yaml
+except Exception:  # pragma: no cover - fallback if PyYAML missing
+    yaml = None  # type: ignore[assignment]
+
+
 class LSEImpactSimulator:
     """Simulates impacts for the London Stock Exchange environment."""
 
+    EXPECTED_SCHEMA = {
+        "market": str,
+        "initial_price": (int, float),
+        "volatility": (int, float),
+    }
+
+    def __init__(self) -> None:
+        self.config: Dict[str, Any] = {}
+
     def load_config(self, config_path: str) -> None:
-        """Load simulation configuration parameters."""
-        pass
+        """Load simulation configuration parameters from JSON or YAML."""
+        path = Path(config_path)
+        with path.open("r", encoding="utf-8") as handle:
+            if path.suffix.lower() in {".yaml", ".yml"}:
+                if yaml is None:
+                    raise ImportError("PyYAML is required for YAML configuration")
+                self.config = yaml.safe_load(handle)
+            else:
+                self.config = json.load(handle)
 
     def validate(self) -> bool:
         """Validate scenario setup prior to simulation."""
-        pass
+        for key, types in self.EXPECTED_SCHEMA.items():
+            value = self.config.get(key)
+            if value is None or not isinstance(value, types):
+                raise ValueError(f"Invalid or missing config field: {key}")
+        return True
 
     def generate_report(self) -> str:
         """Report outcomes from the simulation run."""
-        pass
+        self.validate()
+
+        market = self.config["market"]
+        initial = float(self.config["initial_price"])
+        volatility = float(self.config["volatility"])
+        predicted_range = initial * volatility
+
+        return (
+            f"Market: {market}\n"
+            f"Initial Price: {initial}\n"
+            f"Volatility: {volatility}\n"
+            f"Predicted Range: {predicted_range}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,5 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pytest==8.4.1",
+    "pyyaml>=6.0.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,6 @@ testpaths = tests/auto_projection_bot \
             tests/gaap_ledger_porter \
             tests/hbs_model_validator \
             tests/multivoice_compliance_ui \
+            tests/lse_impact_simulator \
             tests/phase12 \
             tests/prep

--- a/tests/lse_impact_simulator/test_core.py
+++ b/tests/lse_impact_simulator/test_core.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+
+from lse_impact_simulator.core import LSEImpactSimulator
+
+
+def _write_config(tmp_path, data, suffix=".json"):
+    file = tmp_path / f"config{suffix}"
+    if suffix in {".yaml", ".yml"}:
+        yaml = pytest.importorskip("yaml")
+        file.write_text(yaml.safe_dump(data))
+    else:
+        file.write_text(json.dumps(data))
+    return file
+
+
+def test_load_config_json(tmp_path):
+    data = {"market": "LSE", "initial_price": 100.0, "volatility": 0.05}
+    config_file = _write_config(tmp_path, data, ".json")
+    sim = LSEImpactSimulator()
+    sim.load_config(str(config_file))
+    assert sim.config == data
+
+
+def test_load_config_yaml(tmp_path):
+    data = {"market": "LSE", "initial_price": 100.0, "volatility": 0.05}
+    config_file = _write_config(tmp_path, data, ".yaml")
+    sim = LSEImpactSimulator()
+    sim.load_config(str(config_file))
+    assert sim.config == data
+
+
+def test_validate_success(tmp_path):
+    data = {"market": "LSE", "initial_price": 100.0, "volatility": 0.05}
+    config_file = _write_config(tmp_path, data)
+    sim = LSEImpactSimulator()
+    sim.load_config(str(config_file))
+    assert sim.validate() is True
+
+
+def test_validate_missing_field(tmp_path):
+    data = {"initial_price": 100.0, "volatility": 0.05}
+    config_file = _write_config(tmp_path, data)
+    sim = LSEImpactSimulator()
+    sim.load_config(str(config_file))
+    with pytest.raises(ValueError):
+        sim.validate()
+
+
+def test_generate_report(tmp_path):
+    data = {"market": "LSE", "initial_price": 100.0, "volatility": 0.05}
+    config_file = _write_config(tmp_path, data)
+    sim = LSEImpactSimulator()
+    sim.load_config(str(config_file))
+    report = sim.generate_report()
+    assert "Market: LSE" in report
+    assert "Initial Price: 100.0" in report
+    assert "Volatility: 0.05" in report
+    assert "Predicted Range:" in report


### PR DESCRIPTION
## Summary
- handle JSON/YAML configuration for LSEImpactSimulator
- validate required fields and generate simple summary report
- test validation paths and config loading

## Testing
- `ruff check lse_impact_simulator/core.py tests/lse_impact_simulator/test_core.py`
- `pytest tests/lse_impact_simulator/test_core.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a8070b8b64832c953dc33c13e348de