### PR TITLE
chore: bump fastify-jwt across services

### DIFF
--- a/prepchef/services/access-svc/package.json
+++ b/prepchef/services/access-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/admin-svc/package.json
+++ b/prepchef/services/admin-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/audit-svc/package.json
+++ b/prepchef/services/audit-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/availability-svc/package.json
+++ b/prepchef/services/availability-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/booking-svc/package.json
+++ b/prepchef/services/booking-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/compliance-svc/package.json
+++ b/prepchef/services/compliance-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/listing-svc/package.json
+++ b/prepchef/services/listing-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/notif-svc/package.json
+++ b/prepchef/services/notif-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/payments-svc/package.json
+++ b/prepchef/services/payments-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",

--- a/prepchef/services/pricing-svc/package.json
+++ b/prepchef/services/pricing-svc/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fastify": "^4.28.1",
-    "fastify-jwt": "^6.7.1",
+    "fastify-jwt": "^7.0.1",
     "zod": "^3.23.8",
     "undici": "^6.19.8",
     "@prep/common": "1.0.0",


### PR DESCRIPTION
## Summary
- update fastify-jwt to ^7.0.1 in all service package.json files

## Testing
- `npm install` *(fails: No matching version found for fastify-jwt@^7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a957233374832c8a2ddf048d74100a