### PR TITLE
Use logging for BCI router and update tests

### DIFF
--- a/phase12/bci_signal_router.py
+++ b/phase12/bci_signal_router.py
@@ -3,16 +3,21 @@
 Future-ready Brain-Computer Interface hooks with fallback.
 """
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 class BCIRouter:
     def __init__(self):
         self.active_mode = "bci"
 
     def handle_signal(self, signal):
         if self.active_mode == "bci" and signal is None:
-            print("BCI failed, falling back to eye-tracking")
+            logger.info("BCI failed, falling back to eye-tracking")
             self.active_mode = "eye_tracking"
         elif self.active_mode == "eye_tracking" and signal is None:
-            print("Eye-tracking failed, using voice control")
+            logger.info("Eye-tracking failed, using voice control")
             self.active_mode = "voice"
         else:
-            print(f"Received signal in {self.active_mode} mode")
+            logger.info("Received signal in %s mode", self.active_mode)

--- a/tests/phase12/test_bci_signal_router.py
+++ b/tests/phase12/test_bci_signal_router.py
@@ -1,15 +1,17 @@
+import logging
 
-def test_bci_router_fallbacks(bci_router, capsys):
-    bci_router.handle_signal(None)
-    captured = capsys.readouterr()
-    assert bci_router.active_mode == "eye_tracking"
-    assert "BCI failed" in captured.out
 
-    bci_router.handle_signal(None)
-    captured = capsys.readouterr()
-    assert bci_router.active_mode == "voice"
-    assert "Eye-tracking failed" in captured.out
+def test_bci_router_fallbacks(bci_router, caplog):
+    with caplog.at_level(logging.INFO):
+        bci_router.handle_signal(None)
+        assert bci_router.active_mode == "eye_tracking"
+        assert "BCI failed" in caplog.text
+        caplog.clear()
 
-    bci_router.handle_signal("ping")
-    captured = capsys.readouterr()
-    assert "Received signal in voice mode" in captured.out
+        bci_router.handle_signal(None)
+        assert bci_router.active_mode == "voice"
+        assert "Eye-tracking failed" in caplog.text
+        caplog.clear()
+
+        bci_router.handle_signal("ping")
+        assert "Received signal in voice mode" in caplog.text


### PR DESCRIPTION
## Summary
- replace prints with logging in BCI signal router
- capture logs in router tests

## Testing
- `ruff check phase12/bci_signal_router.py tests/phase12/test_bci_signal_router.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96e84dcc8832ca8c495f478e63c67