### PR TITLE
Use caplog for input sense test logging capture

### DIFF
--- a/tests/phase12/test_input_sense.py
+++ b/tests/phase12/test_input_sense.py
@@ -1,3 +1,5 @@
+import logging
+
 from phase12.input_sense import SessionContext, detect_input_devices, configure_ui
 
 
@@ -7,8 +9,8 @@ def test_detect_input_devices():
     assert ctx.ui_mode == "gesture-free"
 
 
-def test_configure_ui(capsys):
+def test_configure_ui(caplog):
     ctx = SessionContext(input_mode=["voice"], ui_mode="default")
-    configure_ui(ctx)
-    captured = capsys.readouterr()
-    assert "Configuring UI for ['voice'] in default mode" in captured.out
+    with caplog.at_level(logging.INFO):
+        configure_ui(ctx)
+    assert "Configuring UI for ['voice'] in default mode" in caplog.text


### PR DESCRIPTION
## Summary
- switch input sense UI test from capsys to caplog

## Testing
- `pytest tests/phase12/test_input_sense.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96e85a970832c876f4b9f8a433536