### PR TITLE
Use timezone-aware timestamps in sensor logger

### DIFF
--- a/modules/prep_sync_agent/sensor_logger.py
+++ b/modules/prep_sync_agent/sensor_logger.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 class PrepSyncAgent:
@@ -13,7 +13,7 @@ class PrepSyncAgent:
             "kitchen_id": self.kitchen_id,
             "event": event,
             "value": value,
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         json_data = json.dumps(data)
         self.logger.info(json_data)

--- a/tests/modules/test_sensor_logger.py
+++ b/tests/modules/test_sensor_logger.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 from modules.prep_sync_agent.sensor_logger import PrepSyncAgent
 
@@ -9,6 +10,9 @@ def test_log_event_logs_json(caplog):
     agent = PrepSyncAgent("k1", logger=logger)
     with caplog.at_level(logging.INFO, logger="test.sensor_logger"):
         result = agent.log_event("temp", "100")
-    assert json.loads(result)["event"] == "temp"
+    data = json.loads(result)
+    assert data["event"] == "temp"
+    assert data["timestamp"].endswith("+00:00")
+    assert datetime.fromisoformat(data["timestamp"]).tzinfo == timezone.utc
     assert result in caplog.text
 


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(timezone.utc)` for sensor logs
- validate timestamp in sensor logger tests

## Testing
- `pytest tests/modules/test_sensor_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96e866a98832c8a0724d0c91c46ae