### PR TITLE
chore: move pytest to dev dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Thank you for your interest in contributing! This document will guide you throug
 
 1. **Clone the repository.**
 2. **Install dependencies:** `pip install -e .`
-3. **Run the tests:** `pytest`
+3. **Install dev dependencies:** `pip install -e .[dev]`
+4. **Run the tests:** `pytest`
 
 ### Node projects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "Prep prototypes"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
     "pytest==8.4.1",
 ]


### PR DESCRIPTION
## Summary
- remove pytest from main dependencies
- add pytest as dev optional dependency
- instruct contributors to install dev dependencies

## Testing
- `pytest`
- `ruff check .` *(fails: unused imports)*
- `mypy .` *(fails: duplicate module named `core`)*

------
https://chatgpt.com/codex/tasks/task_e_68a96f8fbe28832cb2872a8091a81e2f