### PR TITLE
feat: add React web workspace

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prep Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.12",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.5.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.26",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Prep Web",
+  "short_name": "Prep",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Prep web app",
+  "icons": []
+}

--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,23 @@
+const CACHE_NAME = 'prep-cache-v1';
+const URLS_TO_CACHE = ['/'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+
+self.addEventListener('push', event => {
+  const data = event.data?.text() || 'Notification';
+  event.waitUntil(
+    self.registration.showNotification('Prep', {
+      body: data,
+    })
+  );
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,24 @@
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import LandingPage from './pages/LandingPage';
+import KitchenBrowser from './pages/KitchenBrowser';
+import BookingCheckout from './pages/BookingCheckout';
+import Dashboard from './pages/Dashboard';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <nav className="p-4 bg-gray-200 flex gap-4">
+        <Link to="/">Home</Link>
+        <Link to="/kitchens">Kitchens</Link>
+        <Link to="/checkout">Checkout</Link>
+        <Link to="/dashboard">Dashboard</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/kitchens" element={<KitchenBrowser />} />
+        <Route path="/checkout" element={<BookingCheckout />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/pages/BookingCheckout.tsx
+++ b/apps/web/src/pages/BookingCheckout.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export default function BookingCheckout() {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const submit = async () => {
+    try {
+      const res = await fetch('/api/bookings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      setStatus(res.ok ? 'Booked!' : 'Failed');
+    } catch {
+      setStatus('Failed');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Checkout</h1>
+      <button className="mt-2 px-4 py-2 bg-blue-500 text-white" onClick={submit}>
+        Confirm Booking
+      </button>
+      {status && <p className="mt-2">{status}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+type Stats = { bookings: number };
+
+export default function Dashboard() {
+  const [stats, setStats] = useState<Stats | null>(null);
+
+  useEffect(() => {
+    fetch('/api/dashboard')
+      .then((r) => r.json())
+      .then(setStats)
+      .catch(() => setStats(null));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Dashboard</h1>
+      {stats ? <p>Bookings: {stats.bookings}</p> : <p>Loading...</p>}
+    </div>
+  );
+}

--- a/apps/web/src/pages/KitchenBrowser.tsx
+++ b/apps/web/src/pages/KitchenBrowser.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+type Kitchen = { id: string; name: string };
+
+export default function KitchenBrowser() {
+  const [kitchens, setKitchens] = useState<Kitchen[]>([]);
+
+  useEffect(() => {
+    fetch('/api/kitchens')
+      .then((res) => res.json())
+      .then(setKitchens)
+      .catch(() => setKitchens([]));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold">Browse Kitchens</h1>
+      <ul className="mt-2 list-disc pl-6">
+        {kitchens.map((k) => (
+          <li key={k.id}>{k.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,0 +1,8 @@
+export default function LandingPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Welcome to Prep</h1>
+      <p>Find and book the perfect kitchen.</p>
+    </div>
+  );
+}

--- a/apps/web/src/tests/BookingCheckout.test.tsx
+++ b/apps/web/src/tests/BookingCheckout.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BookingCheckout from '../pages/BookingCheckout';
+
+describe('BookingCheckout', () => {
+  it('submits booking', async () => {
+    global.fetch = () => Promise.resolve({ ok: true }) as any;
+    render(<BookingCheckout />);
+    fireEvent.click(screen.getByText(/confirm booking/i));
+    await waitFor(() => screen.getByText(/booked!/i));
+    expect(screen.getByText(/booked!/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/tests/Dashboard.test.tsx
+++ b/apps/web/src/tests/Dashboard.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Dashboard from '../pages/Dashboard';
+
+global.fetch = () => Promise.resolve({ json: () => Promise.resolve({ bookings: 5 }) }) as any;
+
+describe('Dashboard', () => {
+  it('shows bookings stat', async () => {
+    render(<Dashboard />);
+    await waitFor(() => screen.getByText(/bookings:/i));
+    expect(screen.getByText(/bookings: 5/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/tests/KitchenBrowser.test.tsx
+++ b/apps/web/src/tests/KitchenBrowser.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import KitchenBrowser from '../pages/KitchenBrowser';
+
+global.fetch = () => Promise.resolve({ json: () => Promise.resolve([]) }) as any;
+
+describe('KitchenBrowser', () => {
+  it('renders heading', async () => {
+    render(<KitchenBrowser />);
+    expect(screen.getByText(/browse kitchens/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/tests/LandingPage.test.tsx
+++ b/apps/web/src/tests/LandingPage.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import LandingPage from '../pages/LandingPage';
+
+describe('LandingPage', () => {
+  it('renders welcome text', () => {
+    render(<LandingPage />);
+    expect(screen.getByText(/welcome to prep/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/tests/setup.ts
+++ b/apps/web/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../.." }]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { '@': resolve(__dirname, 'src') } },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/tests/setup.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold web workspace with React, Vite, and TailwindCSS
- add core pages for landing, kitchen browsing, booking checkout, and dashboard
- add service worker and manifest for offline caching and push notifications
- wire pages to backend APIs and add React Testing Library tests

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36f37a984832c8aec37fdab9ee4da