### PR TITLE
Handle None default in util_func using sentinel

### DIFF
--- a/prep/utility.py
+++ b/prep/utility.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
-def util_func(config: Dict[str, Any], key: str, default: Any | None = None) -> Any:
+_NO_DEFAULT = object()
+
+
+def util_func(config: Dict[str, Any], key: str, default: Any = _NO_DEFAULT) -> Any:
     """Retrieve ``key`` from ``config``.
 
     The ``key`` may represent a dotted path to nested dictionaries.  If any
@@ -19,8 +22,8 @@ def util_func(config: Dict[str, Any], key: str, default: Any | None = None) -> A
     key:
         Dotted path whose value should be returned.
     default:
-        Fallback value if ``key`` is not present.  If ``None`` and the key is
-        missing a :class:`KeyError` is raised.
+        Fallback value if ``key`` is not present.  If not provided and the key
+        is missing a :class:`KeyError` is raised.
 
     Returns
     -------
@@ -33,7 +36,7 @@ def util_func(config: Dict[str, Any], key: str, default: Any | None = None) -> A
         if isinstance(current, dict) and part in current:
             current = current[part]
         else:
-            if default is not None:
+            if default is not _NO_DEFAULT:
                 return default
             raise KeyError(f"{key} not found in configuration")
 

--- a/tests/prep/test_utility.py
+++ b/tests/prep/test_utility.py
@@ -19,6 +19,11 @@ def test_util_func_uses_default(tmp_path):
     assert utility.util_func(config, "missing", default="fallback") == "fallback"
 
 
+def test_util_func_accepts_none_default(tmp_path):
+    config = create_config(tmp_path, {})
+    assert utility.util_func(config, "missing", default=None) is None
+
+
 def test_util_func_missing_key(tmp_path):
     config = create_config(tmp_path, {})
     with pytest.raises(KeyError):


### PR DESCRIPTION
## Summary
- allow `util_func` to distinguish omitted defaults using sentinel object
- add test for explicit `None` default behavior

## Testing
- `ruff check prep/utility.py tests/prep/test_utility.py`
- `pytest tests/prep/test_utility.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36f2a81a8832ca43d171188679f99