### PR TITLE
Allow custom sleep in SafetyDaemon

### DIFF
--- a/modules/kitchen_safety_daemon/daemon.py
+++ b/modules/kitchen_safety_daemon/daemon.py
@@ -1,12 +1,7 @@
 import asyncio
 import logging
 import time
-from typing import Awaitable, Callable, Optional
-
-
-async def _default_sleep(delay: float) -> None:
-    """Default sleep function using ``time.sleep`` in a thread."""
-    await asyncio.to_thread(time.sleep, delay)
+from typing import Callable, Optional
 
 
 class SafetyDaemon:
@@ -14,7 +9,7 @@ class SafetyDaemon:
         self,
         check_interval: int = 60,
         logger: Optional[logging.Logger] = None,
-        sleep_fn: Callable[[float], Awaitable[None]] = _default_sleep,
+        sleep_fn: Callable[[float], None] = time.sleep,
     ):
         self.check_interval = check_interval
         self.logger = logger or logging.getLogger(__name__)
@@ -29,8 +24,12 @@ class SafetyDaemon:
         while not self._stop.is_set():
             # Placeholder for sensor checks
             self.logger.info("Performing safety check...")
+            sleep_task = asyncio.create_task(
+                asyncio.to_thread(self.sleep_fn, self.check_interval)
+            )
+            stop_task = asyncio.create_task(self._stop.wait())
             done, pending = await asyncio.wait(
-                [self.sleep_fn(self.check_interval), self._stop.wait()],
+                [sleep_task, stop_task],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             for task in pending:

--- a/tests/modules/test_kitchen_safety_daemon.py
+++ b/tests/modules/test_kitchen_safety_daemon.py
@@ -5,7 +5,7 @@ from modules.kitchen_safety_daemon.daemon import SafetyDaemon
 
 
 def test_monitor_iterations(caplog):
-    async def fast_sleep(_: float) -> None:
+    def fast_sleep(_: float) -> None:
         pass
 
     async def run() -> None:
@@ -19,8 +19,8 @@ def test_monitor_iterations(caplog):
 
 
 def test_monitor_stop_flag(caplog):
-    async def fast_sleep(_: float) -> None:
-        await asyncio.sleep(0)
+    def fast_sleep(_: float) -> None:
+        pass
 
     async def run() -> None:
         logger = logging.getLogger("test.daemon.stop")


### PR DESCRIPTION
## Summary
- allow injecting a custom sleep function into `SafetyDaemon`
- replace direct `time.sleep` usage with injected sleep
- speed up tests by using a no-op sleep function

## Testing
- `pytest tests/modules/test_kitchen_safety_daemon.py`


------
https://chatgpt.com/codex/tasks/task_e_68b371dfcf6c832c95e19a7e420acf1f