### PR TITLE
Add Playwright E2E test scaffold and CI integration

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,3 +37,27 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install Playwright dependencies
+        run: |
+          cd prepchef/tests/e2e
+          npm install
+          npx playwright install --with-deps
+      - name: Start services
+        run: docker-compose -f prepchef/tests/e2e/docker-compose.yml up -d --build
+      - name: Run Playwright tests
+        run: |
+          cd prepchef/tests/e2e
+          npm test
+      - name: Stop services
+        if: always()
+        run: docker-compose -f prepchef/tests/e2e/docker-compose.yml down

--- a/prepchef/tests/e2e/README.md
+++ b/prepchef/tests/e2e/README.md
@@ -1,2 +1,18 @@
-# Playwright E2E stubs
-# Add scenarios per spec Appendix C.
+# End-to-End Tests
+
+This directory contains Playwright-based end-to-end tests for PrepChef.
+
+## Setup
+
+```
+npm install
+npx playwright install
+```
+
+## Running tests
+
+```
+BASE_URL=http://localhost:3000 npm test
+```
+
+Use the provided `docker-compose.yml` to start dependent services locally before running tests.

--- a/prepchef/tests/e2e/docker-compose.yml
+++ b/prepchef/tests/e2e/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  auth-svc:
+    build: ../../services/auth-svc
+    ports:
+      - '3001:3000'
+  booking-svc:
+    build: ../../services/booking-svc
+    ports:
+      - '3002:3000'
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: example
+    ports:
+      - '5432:5432'

--- a/prepchef/tests/e2e/package.json
+++ b/prepchef/tests/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:ci": "playwright test --reporter=line"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  }
+}

--- a/prepchef/tests/e2e/playwright.config.ts
+++ b/prepchef/tests/e2e/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/prepchef/tests/e2e/specs/auth.spec.ts
+++ b/prepchef/tests/e2e/specs/auth.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('user can log in', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', 'test@example.com');
+  await page.fill('input[name="password"]', 'password');
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL('/dashboard');
+});

--- a/prepchef/tests/e2e/specs/booking.spec.ts
+++ b/prepchef/tests/e2e/specs/booking.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('user can create a booking', async ({ page }) => {
+  await page.goto('/bookings');
+  await page.click('text="New Booking"');
+  await page.fill('input[name="date"]', '2025-01-01');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('text=Booking confirmed')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- scaffold Playwright config and sample auth and booking flows
- add docker-compose for e2e services
- run Playwright tests in CI pipeline

## Testing
- `npm test` *(fails: playwright: not found)*
- `docker compose -f prepchef/tests/e2e/docker-compose.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b36f395344832c8f5c1a0ff09ed02d