### PR TITLE
Add configurable WebSocket timeouts

### DIFF
--- a/phase12/prep_assist_protocol.py
+++ b/phase12/prep_assist_protocol.py
@@ -16,19 +16,38 @@ except ImportError:  # pragma: no cover
 
 PROTOCOL_VERSION = "1.0"
 
-async def send_command(uri: str, command: dict) -> dict:
-    """Send a command to a robot via WebSocket."""
+async def send_command(
+    uri: str,
+    command: dict,
+    send_timeout: float | None = 5.0,
+    recv_timeout: float | None = 5.0,
+) -> dict:
+    """Send a command to a robot via WebSocket.
+
+    Parameters
+    ----------
+    uri:
+        WebSocket URI of the robot.
+    command:
+        Command payload to send.
+    send_timeout:
+        Maximum time in seconds to wait for the send to complete.
+    recv_timeout:
+        Maximum time in seconds to wait for the response.
+    """
     if getattr(websockets, "connect", None) is None:  # pragma: no cover - dependency missing
         raise ImportError("websockets library is required")
     try:
         async with websockets.connect(uri) as ws:
             try:
-                await ws.send(json.dumps(command))
+                await asyncio.wait_for(
+                    ws.send(json.dumps(command)), timeout=send_timeout
+                )
             except Exception as exc:
                 logging.error("Failed to send command to %s: %s", uri, exc)
                 raise RuntimeError("WebSocket send failed") from exc
             try:
-                response = await ws.recv()
+                response = await asyncio.wait_for(ws.recv(), timeout=recv_timeout)
             except Exception as exc:
                 logging.error("Failed to receive response from %s: %s", uri, exc)
                 raise RuntimeError("WebSocket receive failed") from exc

--- a/tests/phase12/test_prep_assist_protocol.py
+++ b/tests/phase12/test_prep_assist_protocol.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -42,6 +43,46 @@ def test_send_command_receive_failure():
     async def run():
         with patch("phase12.prep_assist_protocol.websockets.connect", return_value=connect_cm):
             await prep_assist_protocol.send_command("ws://robot", {"a": 1})
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())
+
+
+def test_send_command_send_timeout():
+    mock_ws = AsyncMock()
+
+    async def never_send(*args, **kwargs):  # pragma: no cover - helper
+        await asyncio.sleep(0.1)
+
+    mock_ws.send.side_effect = never_send
+    mock_ws.recv.return_value = json.dumps({"ok": True})
+    connect_cm = AsyncMock()
+    connect_cm.__aenter__.return_value = mock_ws
+    connect_cm.__aexit__.return_value = False
+
+    async def run():
+        with patch("phase12.prep_assist_protocol.websockets.connect", return_value=connect_cm):
+            await prep_assist_protocol.send_command("ws://robot", {"a": 1}, send_timeout=0.01)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run())
+
+
+def test_send_command_receive_timeout():
+    mock_ws = AsyncMock()
+    mock_ws.send.return_value = None
+
+    async def never_recv(*args, **kwargs):  # pragma: no cover - helper
+        await asyncio.sleep(0.1)
+
+    mock_ws.recv.side_effect = never_recv
+    connect_cm = AsyncMock()
+    connect_cm.__aenter__.return_value = mock_ws
+    connect_cm.__aexit__.return_value = False
+
+    async def run():
+        with patch("phase12.prep_assist_protocol.websockets.connect", return_value=connect_cm):
+            await prep_assist_protocol.send_command("ws://robot", {"a": 1}, recv_timeout=0.01)
 
     with pytest.raises(RuntimeError):
         asyncio.run(run())


### PR DESCRIPTION
## Summary
- add send and receive timeouts to WebSocket command protocol
- cover timeout scenarios with new tests

## Testing
- `pytest tests/phase12/test_prep_assist_protocol.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36d4d3aa4832ca346d98bf5944e84