### PR TITLE
fix: sync next version in package.json and pin actionlint

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.12
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@stripe/stripe-js": "^8.11.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.101.1",
-    "next": "^14.2.35",
+    "next": "^16.1.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "stripe": "^20.4.1"


### PR DESCRIPTION
## Root cause

Two CI failures on main, both unrelated to the photo upload feature:

**1. CI / Lint jobs failing with `npm ci` lock file mismatch**

Dependabot PR #619 bumped `next` from `14.2.35` → `16.1.5` in `package-lock.json`, but a merge conflict resolution dropped the matching `package.json` update. That left the constraint at `"^14.2.35"` while the lock file pinned `16.1.5` — a range incompatibility that causes `npm ci` to exit 1 before the build even starts.

**2. Workflow Lint job failing with "unable to find version `v1`"**

`workflow-lint.yml` referenced `rhysd/actionlint@v1`, a floating major tag that doesn't exist for this action. Pinned to `v1.7.12` (current latest release).

## Changes

| File | Change |
|------|--------|
| `package.json` | `"next": "^14.2.35"` → `"next": "^16.1.5"` |
| `.github/workflows/workflow-lint.yml` | `rhysd/actionlint@v1` → `rhysd/actionlint@v1.7.12` |

## Verification

- `npm run build` — passes (19/19 pages, 0 type errors)
- `npm run lint` — 0 ESLint warnings or errors
- `npm test` — 175/175 tests pass

The app was already running on next@16.1.5 locally (the lock file was already at that version); only the declared range in `package.json` needed correcting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js framework dependency to v16.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->